### PR TITLE
lib/oelite: Add --debug-loglines argument to bake command

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -92,6 +92,7 @@ class OEliteBaker:
     def __init__(self, options, args, config):
         self.options = options
         self.debug = self.options.debug
+        self.debug_loglines = self.options.debug_loglines
 
         # Bakery 3 compatibility, configure the logging module
         if (not hasattr(oebakery, "__version__") or
@@ -591,8 +592,14 @@ class OEliteBaker:
         timing_info("Build", start)
 
         if exitcode:
-            for task in failed_task_list:
-                print "ERROR: %s failed  %s"%(task,task.logfn)
+             for task in failed_task_list:
+                print "\nERROR: %s failed  %s"%(task,task.logfn)
+                if self.debug_loglines:
+                    with open(task.logfn, 'r') as fin:
+                        if self.debug_loglines < 0:
+                            print fin.read()
+                        else:
+                            print ''.join(fin.readlines()[-self.debug_loglines:])
         return exitcode
 
 

--- a/lib/oelite/cmd/bake.py
+++ b/lib/oelite/cmd/bake.py
@@ -11,6 +11,9 @@ def add_parser_options(parser):
     parser.add_option("-d", "--debug",
                       action="store_true", default=False,
                       help="Debug the OE-lite metadata")
+    parser.add_option("--debug-loglines",
+                      action="store", default=42, metavar="N",
+                      help="Show last N lines of logfiles of failed tasks (default: 42)")
     return
 
 


### PR DESCRIPTION
Allow specifying number of lines to show (at the end of the build) from
each logfile of failed tasks.  Default is set to 42 lines.

This supersedes PR #5.