### PR TITLE
fetch.py: Fix string manipulation in mirror parsing

### DIFF
--- a/lib/oelite/fetch/fetch.py
+++ b/lib/oelite/fetch/fetch.py
@@ -111,7 +111,8 @@ class OEliteUri:
             (src_uri, mirror_uri) = tuple(mirror)
             m = re.match(src_uri, url)
             if m:
-                mirrors.append((mirror_uri, url[m.end():]))
+                e = url.rfind('/')
+                mirrors.append((mirror_uri, url[e:]))
         return mirrors
 
     def init_filter(self, filterstr):


### PR DESCRIPTION
The list of mirrors is generated from ${MIRRORS} in conf/site.conf,
where each line holds a string to search for in the SRC_URI, and
an alternative mirror to try as fallback.

The search string is matched as a regular expression, allowing more
flexible fallback mirror matching, e.g. using "http://.*" as a search
string will effectively catch all SRC_URI's pointing at HTTP mirrors.

However, the same search string is currently used to cut away
everything but the filename when generating the mirror URL. This is
broken for the example above. Consider this:

PV = "1.2.8"
INGREDIENTS_SUBDIR = "zlib"
SRC_URI = "http://www.zlib.net/zlib-${PV}.tar.gz"
MIRRORS = "http://.*  http://oe-lite.org/mirror/${INGREDIENTS_SUBDIR}/"

Matching "http://.*" on SRC_URI is quite greedy, and will match the
entire string including "zlib-1.2.8.tar.gz", resulting in oe-lite
attempting to fetch from "http://oe-lite.org/mirror/zlib/" instead
of the correct "http://oe-lite.org/mirror/zlib/zlib-1.2.8.tar.gz".

Fix this by searching for the first '/' from the right to substring
the filename from the SRC_URI, thus letting the regex match only
decide wether to try the mirror or not.