### PR TITLE
Issue #27: ply compatibility

### DIFF
--- a/classes/kbuild.oeclass
+++ b/classes/kbuild.oeclass
@@ -1,0 +1,12 @@
+## Class for recipes using kbuild based build system
+##
+## @var EXTRA_OEMAKE_VERBOSE Make argument to control kbuild verbosity.
+
+inherit make
+
+EXTRA_OEMAKE_VERBOSE ?= "V=1"
+EXTRA_OEMAKE += "${EXTRA_OEMAKE_VERBOSE}"
+
+# Local Variables:
+# mode: python
+# End:

--- a/classes/kernel-common.oeclass
+++ b/classes/kernel-common.oeclass
@@ -5,7 +5,7 @@
 
 INHIBIT_PACKAGE_STRIP = "1"
 
-inherit c make kernel-arch
+inherit c kbuild kernel-arch
 
 KERNEL_VERSION_PATCHLEVEL = "${@'.'.join(d.get('PV').split('.')[:2])}"
 

--- a/classes/kernel-modules.oeclass
+++ b/classes/kernel-modules.oeclass
@@ -6,7 +6,7 @@
 RECIPE_TYPES = "machine"
 COMPATIBLE_MACHINES = ".*"
 
-inherit c make kernel-arch kernel-modules-strip
+inherit c kbuild kernel-arch kernel-modules-strip
 
 KERNEL_MODULES_DEPENDS ?= "kernel-dev"
 CLASS_DEPENDS += "${KERNEL_MODULES_DEPENDS}"
@@ -17,7 +17,7 @@ KERNEL_MODULES_COMPILE_MAKE_TARGETS ?= "modules"
 
 kernel_modules_do_compile () {
 	unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS
-	oe_runmake V=1 \
+	oe_runmake \
 		KERNELDIR=${HOST_SYSROOT}${kernelsrcdir} \
 		ARCH=${KERNEL_ARCH} \
 		${KERNEL_MODULES_COMPILE_MAKE_TARGETS}

--- a/lib/oelite/parse/oeparse.py
+++ b/lib/oelite/parse/oeparse.py
@@ -15,7 +15,12 @@ class OEParser(object):
             lexer = oelite.parse.oelexer
         self.lexer = lexer.clone()
         self.lexer.parser = self
-        self.tokens = lexer.lextokens.keys()
+        if type(lexer.lextokens) == set:
+            # ply >= 3.6
+            self.tokens = list(lexer.lextokens)
+        else:
+            # ply <= 3.4
+            self.tokens = lexer.lextokens.keys()
         oelite.util.makedirs("tmp/ply")
         picklefile = "tmp/ply/" + self.__class__.__module__ + ".p"
         self.yacc = ply.yacc.yacc(module=self, debug=0, picklefile=picklefile)


### PR DESCRIPTION
PLY >= 3.6 uses a set instead of a dict for the lextokens. It's just used as a list in the end, so check the type of the return value to determine how to convert the data.