### PR TITLE
Fix LOADADDR for USE_kernel_uimage_entrypoint

### DIFF
--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -142,7 +142,7 @@ do_compile_kernel () {
 		if [ -n "$USE_kernel_uimage_loadaddress" ] ; then
 			LOADADDR="$USE_kernel_uimage_loadaddress"
 		elif [ -n "$USE_kernel_uimage_entrypoint" ] ; then
-			LOADADDR=="$USE_kernel_uimage_entrypoint"
+			LOADADDR="$USE_kernel_uimage_entrypoint"
 		else
 			oe_runmake vmlinux
 			for symbol in ${UIMAGE_ENTRYPOINT_SYMBOL} ; do


### PR DESCRIPTION
This fixes the kernel recipe when USE_kernel_uimage_loadaddr is not set and USE_kernel_uimage_entrypoint is set.