### PR TITLE
RFC: pass MACHINE_ARCH as SDK_MACHINE_ARCH in sdk context

### DIFF
--- a/classes/type/sdk.oeclass
+++ b/classes/type/sdk.oeclass
@@ -20,6 +20,11 @@ require conf/paths/sdk.conf
 require conf/paths/sdk-host.conf
 require conf/paths/sdk-target.conf
 
+# Provide information about the sdk cross target
+addhook set_machine to post_recipe_parse first before blacklist
+def set_machine(d):
+    d["SDK_MACHINE_ARCH"] = d.get("MACHINE_ARCH")
+
 BLACKLIST_VAR += "MACHINE"
 BLACKLIST_PREFIX += "MACHINE_"
 


### PR DESCRIPTION
In my case, I have added [npm](https://www.npmjs.com/) to our SDK image. To ease cross compiling native modules, `npm` is called with a wrapper script that sets it up to use the cross compiler in the SDK:

```
#!/bin/bash

SCRIPT_SRC=$(dirname $BASH_SOURCE)
SCRIPT_DIR=$(readlink -fn $SCRIPT_SRC)
NODE_DIR=$SCRIPT_DIR/../share/src/nodejs
ARCH=arm-cortexa8neon-linux-gnueabi
CPU=$(echo $ARCH | cut -d- -f1)

AR=$ARCH-ar \
CC=$ARCH-cc \
CXX=$ARCH-g++ \
LINK=$ARCH-g++ \
npm_config_arch=$CPU \
npm_config_nodedir=$NODE_DIR \
npm $@
```

This script is generated in oe-lite's sdk context, there is no access to `${MACHINE_ARCH}`, and thus the `ARCH` variable in the script cannot be assigned the correct value.

Make it possible to do so, by preserving `${MACHINE_ARCH}` in an SDK specific variable: `${SDK_MACHINE_ARCH}`.