### PR TITLE
Issue #27: ply compatibility

### DIFF
--- a/lib/oelite/parse/oeparse.py
+++ b/lib/oelite/parse/oeparse.py
@@ -15,7 +15,12 @@ class OEParser(object):
             lexer = oelite.parse.oelexer
         self.lexer = lexer.clone()
         self.lexer.parser = self
-        self.tokens = lexer.lextokens.keys()
+        if type(lexer.lextokens) == set:
+            # ply >= 3.6
+            self.tokens = list(lexer.lextokens)
+        else:
+            # ply <= 3.4
+            self.tokens = lexer.lextokens.keys()
         oelite.util.makedirs("tmp/ply")
         picklefile = "tmp/ply/" + self.__class__.__module__ + ".p"
         self.yacc = ply.yacc.yacc(module=self, debug=0, picklefile=picklefile)


### PR DESCRIPTION
PLY >= 3.6 uses a set instead of a dict for the lextokens. It's just used as a list in the end, so check the type of the return value to determine how to convert the data.

(cherry picked from commit 18b7b4bea9a9315b29c5aa7340a03bcd45c98b4b)