### PR TITLE
class/dupdate-image: Allow override of dupdate_version default USE value

### DIFF
--- a/classes/dupdate-image.oeclass
+++ b/classes/dupdate-image.oeclass
@@ -42,7 +42,7 @@ dupdate_image(){
 
 CLASS_FLAGS += "dupdate_script dupdate_version dupdate_archiveformat"
 DEFAULT_USE_dupdate_script = ""
-DEFAULT_USE_dupdate_version = ""
+DEFAULT_USE_dupdate_version ?= "0"
 DEFAULT_USE_dupdate_archiveformat = "tar"
 
 CLASS_FLAGS += "dupdate_exefile"


### PR DESCRIPTION
Set default value to "0", and allow override in recipe.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>