### PR TITLE
4.0 powerpc32

### DIFF
--- a/classes/c.oeclass
+++ b/classes/c.oeclass
@@ -64,6 +64,12 @@ CFLAGS_OPT_SPEED	?= "-O2 \
 CFLAGS_OPT_SIZE		?= "-Os"
 CFLAGS_OPT_DEBUG	?= "-O1 -g -fno-omit-frame-pointer"
 
+# Enable -fPIC for powerpc architectures to support address
+# space larger than 24 bits
+CFLAGS_OPT_SPEED:>TARGET_CPU_powerpc += " -fPIC"
+CFLAGS_OPT_SIZE:>TARGET_CPU_powerpc += " -fPIC"
+CFLAGS_OPT_DEBUG:>TARGET_CPU_powerpc += " -fPIC"
+
 HOST_CFLAGS_OPT:native		 = "${BUILD_CFLAGS_OPT}"
 HOST_CFLAGS_OPT:cross		 = "${BUILD_CFLAGS_OPT}"
 HOST_CFLAGS_OPT:machine		 = "${MACHINE_CFLAGS_OPT}"

--- a/recipes/eglibc/eglibc-2.18/circular_dependency.patch
+++ b/recipes/eglibc/eglibc-2.18/circular_dependency.patch
@@ -1,0 +1,82 @@
+diff --git eglibc-2_18/libc/Makefile eglibc-2_18/libc/Makefile
+index 51d10b9..74237eb 100644
+--- eglibc-2_18/libc/Makefile
++++ eglibc-2_18/libc/Makefile
+@@ -131,31 +131,7 @@ endif
+ lib-noranlib: subdir_lib
+ 
+ ifeq (yes,$(build-shared))
+-# Build the shared object from the PIC object library.
+-lib: $(common-objpfx)libc.so
+-
+-lib: $(common-objpfx)linkobj/libc.so
+-
+-# Do not filter ld.so out of libc.so link.
+-$(common-objpfx)linkobj/libc.so: link-libc-deps = # empty
+-
+-$(common-objpfx)linkobj/libc.so: $(elfobjdir)/soinit.os \
+-				 $(common-objpfx)linkobj/libc_pic.a \
+-				 $(elfobjdir)/sofini.os \
+-				 $(elfobjdir)/interp.os \
+-				 $(elfobjdir)/ld.so \
+-				 $(shlib-lds)
+-	$(build-shlib)
+-
+-$(common-objpfx)linkobj/libc_pic.a: $(common-objpfx)libc_pic.a \
+-				    $(common-objpfx)sunrpc/librpc_compat_pic.a
+-	$(..)./scripts/mkinstalldirs $(common-objpfx)linkobj
+-	(cd $(common-objpfx)linkobj; \
+-	 $(AR) x ../libc_pic.a; \
+-	 rm $$($(AR) t ../sunrpc/librpc_compat_pic.a | sed 's/^compat-//'); \
+-	 $(AR) x ../sunrpc/librpc_compat_pic.a; \
+-	 $(AR) cr libc_pic.a *.os; \
+-	 rm *.os)
++lib: $(common-objpfx)libc.so $(common-objpfx)linkobj/libc.so
+ endif
+ 
+ 
+diff --git eglibc-2_18/libc/Makerules eglibc-2_18/libc/Makerules
+index 4bd6c13..9fb6bb2 100644
+--- eglibc-2_18/libc/Makerules
++++ eglibc-2_18/libc/Makerules
+@@ -595,16 +595,39 @@ ifneq ($(versioning),yes)
+ libc_gcclibs := -lgcc_eh
+ endif
+ 
++# Build a possibly-modified version of libc_pic.a for use in building
++# linkobj/libc.so.
++$(common-objpfx)linkobj/libc_pic.a: $(common-objpfx)libc_pic.a \
++				    $(common-objpfx)sunrpc/librpc_compat_pic.a
++	$(..)./scripts/mkinstalldirs $(common-objpfx)linkobj
++	(cd $(common-objpfx)linkobj; \
++	 $(AR) x ../libc_pic.a; \
++	 rm $$($(AR) t ../sunrpc/librpc_compat_pic.a | sed 's/^compat-//'); \
++	 $(AR) x ../sunrpc/librpc_compat_pic.a; \
++	 $(AR) cr libc_pic.a *.os; \
++	 rm *.os)
++
+ # Do not filter ld.so out of libc.so link.
+ $(common-objpfx)libc.so: link-libc-deps = # empty
++$(common-objpfx)linkobj/libc.so: link-libc-deps = # empty
+ 
+ # Use our own special initializer and finalizer files for libc.so.
+ $(common-objpfx)libc.so: $(elfobjdir)/soinit.os \
+ 			 $(common-objpfx)libc_pic.os$(libc_pic_clean) \
+ 			 $(elfobjdir)/sofini.os \
+-			 $(elfobjdir)/interp.os $(elfobjdir)/ld.so \
++			 $(elfobjdir)/interp.os \
++			 $(elfobjdir)/ld.so \
+ 			 $(shlib-lds)
+ 	$(build-shlib) $(libc_gcclibs)
++
++$(common-objpfx)linkobj/libc.so: $(elfobjdir)/soinit.os \
++				 $(common-objpfx)linkobj/libc_pic.a \
++				 $(elfobjdir)/sofini.os \
++				 $(elfobjdir)/interp.os \
++				 $(elfobjdir)/ld.so \
++				 $(shlib-lds)
++	$(build-shlib) $(libc_gcclibs)
++
+ # eglibc: ifeq ($(versioning),yes)
+ $(common-objpfx)libc.so: $(common-objpfx)libc.map
+ # eglibc: endif

--- a/recipes/eglibc/eglibc-2.18/gettimeofday_time.patch
+++ b/recipes/eglibc/eglibc-2.18/gettimeofday_time.patch
@@ -1,0 +1,58 @@
+--- eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/gettimeofday.c
++++ eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/gettimeofday.c
+@@ -44,8 +44,24 @@ asm (".type __gettimeofday, %gnu_indirect_function");
+ /* This is doing "libc_hidden_def (__gettimeofday)" but the compiler won't
+    let us do it in C because it doesn't know we're defining __gettimeofday
+    here in this file.  */
+-asm (".globl __GI___gettimeofday\n"
+-     "__GI___gettimeofday = __gettimeofday");
++asm (".globl __GI___gettimeofday");
++
++/* __GI___gettimeofday is defined as hidden and for ppc32 it enables the
++   compiler make a local call (symbol@local) for internal GLIBC usage. It
++   means the PLT won't be used and the ifunc resolver will be called directly.
++   For ppc64 a call to a function in another translation unit might use a
++   different toc pointer thus disallowing direct branchess and making internal
++   ifuncs calls safe.  */
++#ifdef __powerpc64__
++asm ("__GI___gettimeofday = __gettimeofday");
++#else
++int
++__gettimeofday_vsyscall (struct timeval *tv, struct timezone *tz)
++{
++  return INLINE_VSYSCALL (gettimeofday, 2, tv, tz);
++}
++asm ("__GI___gettimeofday = __gettimeofday_vsyscall");
++#endif
+ 
+ #else
+ 
+--- eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/time.c
++++ eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/time.c
+@@ -54,8 +54,24 @@ asm (".type time, %gnu_indirect_function");
+ /* This is doing "libc_hidden_def (time)" but the compiler won't
+  * let us do it in C because it doesn't know we're defining time
+  * here in this file.  */
+-asm (".globl __GI_time\n"
+-     "__GI_time = time");
++asm (".globl __GI_time");
++
++/* __GI_time is defined as hidden and for ppc32 it enables the
++   compiler make a local call (symbol@local) for internal GLIBC usage. It
++   means the PLT won't be used and the ifunc resolver will be called directly.
++   For ppc64 a call to a function in another translation unit might use a
++   different toc pointer thus disallowing direct branchess and making internal
++   ifuncs calls safe.  */
++#ifdef __powerpc64__
++asm ("__GI_time = time");
++#else
++time_t
++__time_vsyscall (time_t *t)
++{
++  return INLINE_VSYSCALL (time, 1, t);
++}
++asm ("__GI_time = __time_vsyscall");
++#endif
+ 
+ #else
+ 

--- a/recipes/eglibc/eglibc-2.18/powerpc_fPIC.patch
+++ b/recipes/eglibc/eglibc-2.18/powerpc_fPIC.patch
@@ -1,0 +1,11 @@
+--- eglibc-2_18/libc/sysdeps/powerpc/powerpc32/Makefile
++++ eglibc-2_18/libc/sysdeps/powerpc/powerpc32/Makefile
+@@ -20,7 +20,7 @@ endif
+ # so that's at least 8192 entries.  Since libc only uses about 2000 entries,
+ # we want to use -fpic, because this generates fewer relocs.
+ ifeq (yes,$(build-shared))
+-pic-ccflag = -fpic
++pic-ccflag = -fPIC
+ endif
+ 
+ ifeq ($(subdir),csu)

--- a/recipes/eglibc/eglibc_2.18-r24943.oe
+++ b/recipes/eglibc/eglibc_2.18-r24943.oe
@@ -10,5 +10,10 @@ SRC_URI += "file://typedef-caddr.patch;striplevel=2"
 SRC_URI += "file://bindir-paths.patch;striplevel=2"
 EXTRA_OECONF += "libc_cv_rootsbindir=${base_sbindir}"
 
+# On PowerPC32 references from within libc to gettimeofday
+# and time got resolved to placeholder versions of these system
+# calls.
+SRC_URI:>TARGET_CPU_powerpc += "file://gettimeofday_time.patch;striplevel=2"
+
 # Fix circular dependencies in makefile
 SRC_URI += "file://circular_dependency.patch;striplevel=2"

--- a/recipes/eglibc/eglibc_2.18-r24943.oe
+++ b/recipes/eglibc/eglibc_2.18-r24943.oe
@@ -10,6 +10,9 @@ SRC_URI += "file://typedef-caddr.patch;striplevel=2"
 SRC_URI += "file://bindir-paths.patch;striplevel=2"
 EXTRA_OECONF += "libc_cv_rootsbindir=${base_sbindir}"
 
+# Compile PowerPC startup code with -fPIC instead of -fpic
+SRC_URI:>TARGET_CPU_powerpc += "file://powerpc_fPIC.patch;striplevel=2"
+
 # On PowerPC32 references from within libc to gettimeofday
 # and time got resolved to placeholder versions of these system
 # calls.

--- a/recipes/eglibc/eglibc_2.18-r24943.oe
+++ b/recipes/eglibc/eglibc_2.18-r24943.oe
@@ -9,3 +9,6 @@ SRC_URI += "file://typedef-caddr.patch;striplevel=2"
 # Fixes for handling of bindir, sbindir and so on
 SRC_URI += "file://bindir-paths.patch;striplevel=2"
 EXTRA_OECONF += "libc_cv_rootsbindir=${base_sbindir}"
+
+# Fix circular dependencies in makefile
+SRC_URI += "file://circular_dependency.patch;striplevel=2"


### PR DESCRIPTION
Various fixes for powerpc32 build.

The circular dependency and gettimeofday commits are in glibc-2.19 and not necessary for the master branch.

The 32 bit addressing patch may be relevant for master in some form. It can be improved

  - Maybe use flag to enable, there is some performance impact since all calls resolved by the dynamic linker will be 32 bit.

  - The toolchain should probably use -fPIC as default if 32 bit addressing is supported