### PR TITLE
Fix for gettimeofday and time for powerpc32

### DIFF
--- a/recipes/eglibc/eglibc-2.18/gettimeofday_time.patch
+++ b/recipes/eglibc/eglibc-2.18/gettimeofday_time.patch
@@ -1,0 +1,58 @@
+--- eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/gettimeofday.c
++++ eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/gettimeofday.c
+@@ -44,8 +44,24 @@ asm (".type __gettimeofday, %gnu_indirect_function");
+ /* This is doing "libc_hidden_def (__gettimeofday)" but the compiler won't
+    let us do it in C because it doesn't know we're defining __gettimeofday
+    here in this file.  */
+-asm (".globl __GI___gettimeofday\n"
+-     "__GI___gettimeofday = __gettimeofday");
++asm (".globl __GI___gettimeofday");
++
++/* __GI___gettimeofday is defined as hidden and for ppc32 it enables the
++   compiler make a local call (symbol@local) for internal GLIBC usage. It
++   means the PLT won't be used and the ifunc resolver will be called directly.
++   For ppc64 a call to a function in another translation unit might use a
++   different toc pointer thus disallowing direct branchess and making internal
++   ifuncs calls safe.  */
++#ifdef __powerpc64__
++asm ("__GI___gettimeofday = __gettimeofday");
++#else
++int
++__gettimeofday_vsyscall (struct timeval *tv, struct timezone *tz)
++{
++  return INLINE_VSYSCALL (gettimeofday, 2, tv, tz);
++}
++asm ("__GI___gettimeofday = __gettimeofday_vsyscall");
++#endif
+ 
+ #else
+ 
+--- eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/time.c
++++ eglibc-2_18/libc/sysdeps/unix/sysv/linux/powerpc/time.c
+@@ -54,8 +54,24 @@ asm (".type time, %gnu_indirect_function");
+ /* This is doing "libc_hidden_def (time)" but the compiler won't
+  * let us do it in C because it doesn't know we're defining time
+  * here in this file.  */
+-asm (".globl __GI_time\n"
+-     "__GI_time = time");
++asm (".globl __GI_time");
++
++/* __GI_time is defined as hidden and for ppc32 it enables the
++   compiler make a local call (symbol@local) for internal GLIBC usage. It
++   means the PLT won't be used and the ifunc resolver will be called directly.
++   For ppc64 a call to a function in another translation unit might use a
++   different toc pointer thus disallowing direct branchess and making internal
++   ifuncs calls safe.  */
++#ifdef __powerpc64__
++asm ("__GI_time = time");
++#else
++time_t
++__time_vsyscall (time_t *t)
++{
++  return INLINE_VSYSCALL (time, 1, t);
++}
++asm ("__GI_time = __time_vsyscall");
++#endif
+ 
+ #else
+ 

--- a/recipes/eglibc/eglibc_2.18-r24943.oe
+++ b/recipes/eglibc/eglibc_2.18-r24943.oe
@@ -9,3 +9,9 @@ SRC_URI += "file://typedef-caddr.patch;striplevel=2"
 # Fixes for handling of bindir, sbindir and so on
 SRC_URI += "file://bindir-paths.patch;striplevel=2"
 EXTRA_OECONF += "libc_cv_rootsbindir=${base_sbindir}"
+
+# On PowerPC32 references from within libc to gettimeofday
+# and time got resolved to placeholder versions of these system
+# calls.
+SRC_URI:>TARGET_CPU_powerpc += "file://gettimeofday_time.patch;striplevel=2"
+


### PR DESCRIPTION
On powerpc32, internal calls to gettimeofday and time got
resolved to placeholder versions of these library calls
which return bogus data.

Based on 736c304a1ab4cee36a2f3343f1698bc0abae4608 in glibc.

Fixed in glibc 2.19.

Signed-off-by: Klaus Henning Sorensen <klaus.sorensen@prevas.dk>