### PR TITLE
glibc: fix 64bit sdk build

### DIFF
--- a/recipes/glibc/glibc.inc
+++ b/recipes/glibc/glibc.inc
@@ -43,6 +43,7 @@ do_configure_siteinfo() {
 }
 
 EXTRA_OECONF += "\
+	libc_cv_slibdir='/lib' \
 	--disable-profile \
 	--with-tls \
 	--with-headers=${HOST_SYSROOT}${includedir} \


### PR DESCRIPTION
without this, the libdir related variables ends up being set to
/../lib resulting in installation outside the install dir.

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>