### PR TITLE
image_mdev.oeclass: support use flag entries in mdev.conf

### DIFF
--- a/classes/image_mdev.oeclass
+++ b/classes/image_mdev.oeclass
@@ -23,6 +23,18 @@ image_preprocess_mdev () {
 	rm -rf $cwd/${mdevdir}
 }
 
+# USE_image_mdev_lines: lines to add to /etc/mdev.conf
+# syntax:  <match> <user/uid>:<group/gid> <mode> [=<subfolder>]
+# example: spidev.* 0:spi 660
+CLASS_FLAGS += "image_mdev_lines"
+IMAGE_PREPROCESS_FUNCS:>USE_image_mdev_lines = " image_preprocess_mdev_lines"
+image_preprocess_mdev_lines() {
+    cwd=`pwd`
+    echo -e "\n# USE_image_mdev_lines" >> $cwd/${mdevconf}
+    echo -e "${USE_image_mdev_lines}" >> $cwd/${mdevconf}
+}
+image_preprocess_mdev_lines[expand] = 3
+
 # Local Variables:
 # mode: python
 # End:


### PR DESCRIPTION
Add post rstage function to add entries from USE_image_mdev_nodes
in etc/mdev.conf.

To make sure the entries are added after any recipe defined sections,
the existing image_preprocess_mdev() function in IMAGE_PREPROCESS_FUNCS
is changed to run as post rstage, as the newly created do_rstage_mdev()
function is written in python.

The function reads entries in USE_image_mdev_nodes and creates appends
lines to etc/mdev.conf with the configured match-strings and group-spec,
bases on the following syntax:
<match>:<group>

Example setting in e.g. distro configuration:
DISTRO_USE_image_mdev_nodes = "spidev.*:spi"