### PR TITLE
image_depmod: add class to run depmod on image modules

### DIFF
--- a/classes/image_depmod.oeclass
+++ b/classes/image_depmod.oeclass
@@ -1,0 +1,15 @@
+## Class to run depmod on final images to resolve module dependencies
+## including modules built out-of-tree.
+
+CLASS_DEPENDS += "native:util/depmod"
+
+IMAGE_PREPROCESS_FUNCS += "image_preprocess_depmod"
+image_preprocess_depmod() {
+    for version in $(ls lib/modules); do
+        depmod -a -b . $version
+    done
+}
+
+# Local Variables:
+# mode: python
+# End:


### PR DESCRIPTION
When collecting modules from out-of-tree builds, one must run depmod at
image creation time to resolve module dependencies. E.g. with wifi
drivers from linux-backports fails to load at first boot if dependencies
are missing.