### PR TITLE
glibc: add patch to avoid asserting in SDK binaries

### DIFF
--- a/recipes/glibc/glibc-2.21/avoid_assert_on_incompatible_locale_settings.patch
+++ b/recipes/glibc/glibc-2.21/avoid_assert_on_incompatible_locale_settings.patch
@@ -1,0 +1,46 @@
+From 0062ace2292effc4135c15ea99b1931fea5e0203 Mon Sep 17 00:00:00 2001
+From: =?utf8?q?Ludovic=20Court=C3=A8s?= <ludo@gnu.org>
+Date: Tue, 27 Oct 2015 13:33:26 +0100
+Subject: [PATCH] Gracefully handle incompatible locale data
+
+* locale/loadlocale.c (_nl_intern_locale_data): Change assertion
+on CNT to a conditional jump to 'puntdata'.
+---
+ ChangeLog           | 5 +++++
+ locale/loadlocale.c | 7 ++++---
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+#diff --git a/ChangeLog b/ChangeLog
+#index 4ce7a92..29ec912 100644
+#--- a/ChangeLog
+#+++ b/ChangeLog
+#@@ -1,3 +1,8 @@
+#+2015-10-27  Ludovic CourtÃ¨s  <ludo@gnu.org>
+#+
+#+	* locale/loadlocale.c (_nl_intern_locale_data): Change assertion
+#+	on CNT to a conditional jump to 'puntdata'.
+#+
+# 2015-10-27  Joseph Myers  <joseph@codesourcery.com>
+# 
+# 	* configure.ac (libc_cv_gcc___thread): Remove configure test.
+diff --git a/locale/loadlocale.c b/locale/loadlocale.c
+index fdba6e9..dcbb833 100644
+--- a/locale/loadlocale.c
++++ b/locale/loadlocale.c
+@@ -121,9 +121,10 @@ _nl_intern_locale_data (int category, const void *data, size_t datasize)
+       switch (category)
+ 	{
+ #define CATTEST(cat) \
+-	case LC_##cat:							      \
+-	  assert (cnt < (sizeof (_nl_value_type_LC_##cat)		      \
+-			 / sizeof (_nl_value_type_LC_##cat[0])));	      \
++	case LC_##cat:						\
++	  if (cnt >= (sizeof (_nl_value_type_LC_##cat)		\
++		      / sizeof (_nl_value_type_LC_##cat[0])))	\
++	    goto puntdata;					\
+ 	  break
+ 	  CATTEST (NUMERIC);
+ 	  CATTEST (TIME);
+-- 
+1.9.4
+

--- a/recipes/glibc/glibc_2.21.oe
+++ b/recipes/glibc/glibc_2.21.oe
@@ -5,6 +5,7 @@ SRC_URI += "file://multilib-paths.patch"
 SRC_URI += "file://typedef-caddr.patch"
 SRC_URI += "file://git-65f6f938-o-tmpfile-flags.patch"
 SRC_URI += "file://git-59b61c82-o-tmpfile-nondefault-arch.patch;patchlevel=0"
+SRC_URI += "file://avoid_assert_on_incompatible_locale_settings.patch"
 
 SRC_URI += "file://rootsbindir.patch"
 EXTRA_OECONF += "libc_cv_rootsbindir=${base_sbindir}"


### PR DESCRIPTION
Without this patch, binaries in the SDK will fail like:

".arm-cortexa9neon-linux-gnueabi-as: loadlocale.c:130:
 _nl_intern_locale_data: Assertion `cnt < (sizeof
(_nl_value_type_LC_COLLATE) / sizeof
(_nl_value_type_LC_COLLATE[0]))' failed."

on modern Linux hosts. patch taken from upstream.