### PR TITLE
Log and tmp file handling

### DIFF
--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -133,7 +133,7 @@ class ShellFunction(OEliteFunction):
         runfile.write("#!/bin/bash -e\n\n")
         if os.path.exists(runsymlink) or os.path.islink(runsymlink):
             os.remove(runsymlink)
-        os.symlink(runfn, runsymlink)
+        os.symlink(os.path.basename(runfn), runsymlink)
 
         vars = self.meta.keys()
         vars.sort()

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -122,7 +122,7 @@ class ShellFunction(OEliteFunction):
         return
 
     def __call__(self):
-        runfn = "%s/%s.%s.run" % (self.tmpdir, self.name, str(os.getpid()))
+        runfn = "%s/%s.%s.run" % (self.tmpdir, self.name, self.meta.get("DATETIME"))
         runsymlink = "%s/%s.run" % (self.tmpdir, self.name)
 
         body = self.meta.get(self.name)

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -198,7 +198,7 @@ class OEliteTask:
 
         # Setup stdin, stdout and stderr redirection
         stdin = open("/dev/null", "r")
-        self.logfn = "%s/%s.%s.log"%(function.tmpdir, self.name, str(os.getpid()))
+        self.logfn = "%s/%s.%s.log"%(function.tmpdir, self.name, meta.get("DATETIME"))
         self.logsymlink = "%s/%s.log"%(function.tmpdir, self.name)
         oelite.util.makedirs(os.path.dirname(self.logfn))
         try:

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -212,7 +212,7 @@ class OEliteTask:
 
         if os.path.exists(self.logsymlink) or os.path.islink(self.logsymlink):
             os.remove(self.logsymlink)
-        os.symlink(self.logfn, self.logsymlink)
+        os.symlink(os.path.basename(self.logfn), self.logsymlink)
 
         real_stdin = os.dup(sys.stdin.fileno())
         real_stdout = os.dup(sys.stdout.fileno())


### PR DESCRIPTION
   lib/oelite: Use date-time stamp for .log and .run files
    
    Example:
    new: do_configure.20151213141516.run   (2015/12/13 14:15:16)
    old: do_configure.32768.run
    
    This replaces the PID based filename which was not uniqe and
    resulted in .log and .run files being overwritten (especially if running
    oe bake in docker). The UTC timestamp is more likely to generate a uniqe
    file. (except on build hosts with broken/no RTC, during local hard time
    adjustments, leap second, ...)
