### PR TITLE
Remove zip and libz from provides.conf

### DIFF
--- a/conf/provided/all.conf
+++ b/conf/provided/all.conf
@@ -19,6 +19,7 @@ native:gzip native:bzip2 native:tar native:unzip native:xz \
 native:patch native:quilt native:diffstat \
 native:perl native:perl-runtime \
 native:python-runtime \
+native:ruby \
 native:texinfo native:doxygen \
 native:texlive-extra-utils native:texlive-latex-extra native:latex-xcolor \
 native:util-linux native:coreutils \

--- a/conf/provided/all.conf
+++ b/conf/provided/all.conf
@@ -15,7 +15,7 @@ native:m4 \
 native:git native:cvs native:svn native:mercurial native:bzr \
 native:autoconf native:automake native:gnu-config \
 native:bc \
-native:gzip native:bzip2 native:tar native:unzip native:zip native:xz \
+native:gzip native:bzip2 native:tar native:unzip native:xz \
 native:patch native:quilt native:diffstat \
 native:perl native:perl-runtime \
 native:python-runtime \
@@ -28,4 +28,5 @@ native:mtd-utils-mkfs-jffs2 \
 native:wget \
 native:gawk native:sed native:grep \
 native:libiconv \
+native:libacl1-dev \
 "

--- a/conf/provided/osx.conf
+++ b/conf/provided/osx.conf
@@ -14,7 +14,7 @@ native:m4 \
 native:git native:cvs native:svn native:mercurial native:bzr \
 native:autoconf native:automake native:gnu-config \
 native:bc \
-native:gzip native:bzip2 native:tar native:unzip native:zip native:xz \
+native:gzip native:bzip2 native:tar native:unzip native:xz \
 native:patch native:quilt native:diffstat \
 native:perl native:perl-runtime \
 native:python-runtime \


### PR DESCRIPTION
Remove from provide.conf and therby use the oe-lite build zip and libz versions.

zip and libz is not directly mentioned in the setup/* files so no cleanup needed there.