### PR TITLE
class/runit: Add support for creating service down file with USE flag

### DIFF
--- a/classes/runit.oeclass
+++ b/classes/runit.oeclass
@@ -61,6 +61,10 @@ python do_install_runit () {
             os.makedirs(dst_dir)
         shutil.copy(script, dst)
 	os.chmod(dst, stat.S_IRWXU|stat.S_IRGRP|stat.S_IXGRP|stat.S_IROTH|stat.S_IXOTH)
+
+        down = d.get('USE_%s_down'%(option))
+        if down:
+            open(os.path.join(dst_dir, 'down'), 'w').close()
 }
 
 # Local Variables:


### PR DESCRIPTION
In a recipe with a 'foobar' service, controlled by the USE_foobar_runit
flag, adding a USE_foobar_runit_down flag, and enabling it will cause a
down file to be created in the service dir, and thus prevent the service
from being started automatically.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>