### PR TITLE
mingw-w64-crt: disable parallel make

### DIFF
--- a/recipes/mingw-w64/mingw-w64-crt.inc
+++ b/recipes/mingw-w64/mingw-w64-crt.inc
@@ -16,3 +16,7 @@ FILES_${PN} = ""
 PROVIDES_${PN} = "libc libm"
 DEPENDS_${PN} = "${PN}-dev_${PV} mingw-w64-headers"
 DEPENDS_${PN}-dev = ""
+
+# Parallel make is racy:
+# https://github.com/crosstool-ng/crosstool-ng/issues/246
+PARALLEL_MAKE = ""


### PR DESCRIPTION
When building with parallel make, mingw sometimes fails with the error
below. Same issue has been reported in crosstool-ng:
https://github.com/crosstool-ng/crosstool-ng/issues/246

Stabilize building of mingw-w64-crt by disabling parallel builds.

make[3]: Entering directory `/oe-lite/tmp/work/sdk/i686-sdk_mmx-mingw32/mingw-w64-crt-3.1.0/build/mingw-w64-crt'
i686-sdk_mmx-mingw32-gcc -E -x c /oe-lite/tmp/work/sdk/i686-sdk_mmx-mingw32/mingw-w64-crt-3.1.0/src/mingw-w64-v3.1.0/mingw-w64-crt/lib32/msvcrt.def.in -Wp,-w -I/oe-lite/tmp/work/sdk/i686-sdk_mmx-mingw32/mingw-w64-crt-3.1.0/src/mingw-w64-v3.1.0/mingw-w64-crt/def-include | /bin/sed 's/^#/;/' >lib32/msvcrt.def
/bin/sh: lib32/msvcrt.def: No such file or directory
/oe-lite/tmp/work/sdk/i686-sdk_mmx-mingw32/mingw-w64-crt-3.1.0/src/mingw-w64-v3.1.0/mingw-w64-crt/lib32/msvcrt.def.in:5:0: fatal error: when writing output to : Broken pipe