### PR TITLE
conf/provided: Align minimal.conf, default.conf and all.conf

### DIFF
--- a/conf/provided/all.conf
+++ b/conf/provided/all.conf
@@ -1,33 +1,8 @@
-# python-native should be here but python relies on building 
-# its own in staging
-ASSUME_PROVIDED = "\
-native:gcc-bootstrap \
-native:binutils native:cc native:c++ native:libgcc native:libc native:ld-so \
-native:libgcc native:libdl native:libstdc++ native:libsupc++ \
-native:libresolv native:libutil native:libcrypt native:libpthread \
-native:libthread_db native:libbfd native:lib native:libm \
-native:librt native:libanl native:libBrokenLocale native:libnsl \
-native:libmemusage native:libpcprofile native:libSegFault \
-native:libnss_files native:libnss_dns native:libnss_compat \
-native:libnss_nis native:libnss_nisplus native:libnss_hesiod \
-native:pkgconfig \
-native:m4 \
-native:git native:cvs native:svn native:mercurial native:bzr \
-native:autoconf native:automake native:gnu-config \
-native:bc \
-native:gzip native:bzip2 native:tar native:unzip native:xz \
-native:patch native:quilt native:diffstat \
-native:perl native:perl-runtime \
-native:python-runtime \
+require conf/provided/default.conf
+
+ASSUME_PROVIDED += "\
 native:ruby \
-native:texinfo native:makeinfo native:doxygen \
-native:texlive-extra-utils native:texlive-latex-extra native:latex-xcolor \
-native:util-linux native:coreutils \
-native:shasum \
-native:flex native:bison \
 native:mtd-utils-mkfs-jffs2 \
-native:wget \
-native:gawk native:sed native:grep \
 native:libiconv \
 native:libacl1-dev \
 "

--- a/conf/provided/default.conf
+++ b/conf/provided/default.conf
@@ -1,28 +1,13 @@
-# python-native should be here but python relies on building 
-# its own in staging
-ASSUME_PROVIDED = "\
-native:gcc-bootstrap \
-native:binutils native:cc native:c++ native:libgcc native:libc native:ld-so \
-native:libgcc native:libdl native:libstdc++ native:libsupc++ \
-native:libresolv native:libutil native:libcrypt native:libpthread \
-native:libthread_db native:libbfd native:lib native:libm \
-native:librt native:libanl native:libBrokenLocale native:libnsl \
-native:libmemusage native:libpcprofile native:libSegFault \
-native:libnss_files native:libnss_dns native:libnss_compat \
-native:libnss_nis native:libnss_nisplus native:libnss_hesiod \
+require conf/provided/minimal.conf
+
+ASSUME_PROVIDED += "\
 native:pkgconfig \
 native:m4 \
-native:git native:cvs native:svn native:mercurial native:bzr \
-native:autoconf native:automake native:gnu-config \
+native:autoconf native:automake \
 native:bc \
-native:gzip native:bzip2 native:zip native:xz \
-native:patch native:quilt native:diffstat \
-native:perl native:perl-runtime \
-native:python-runtime \
+native:bzip2 \
 native:texinfo native:makeinfo native:doxygen \
 native:texlive-extra-utils native:texlive-latex-extra native:latex-xcolor \
-native:util-linux native:coreutils \
-native:shasum \
 native:flex native:bison \
 native:wget \
 "

--- a/conf/provided/minimal.conf
+++ b/conf/provided/minimal.conf
@@ -12,7 +12,7 @@ native:libnss_files native:libnss_dns native:libnss_compat \
 native:libnss_nis native:libnss_nisplus native:libnss_hesiod \
 native:git native:cvs native:svn native:mercurial native:bzr \
 native:gnu-config \
-native:gzip native:zip native:unzip native:tar native:xz \
+native:gzip native:unzip native:tar native:xz \
 native:patch native:quilt native:diffstat \
 native:perl native:perl-runtime \
 native:python-runtime \


### PR DESCRIPTION
By rewriting all.conf to amend default.conf, and default.conf to amend
minimal.conf, it should be easier to make consistent changes to these
in the future.

As a consequence of this change, native:zip is dropped from minimal.conf
and default.conf, as it was already removed from all.conf
(see 367b92d25983bf48647e4528897aa2d3ddde9425).

Signed-off-by: Esben Haabendal <esben@haabendal.dk>