### PR TITLE
classes: Use util/mkimage in dependencies

### DIFF
--- a/classes/cpio-image.oeclass
+++ b/classes/cpio-image.oeclass
@@ -21,7 +21,7 @@ IMAGE_CREATE_FUNCS += "cpio_image"
 
 inherit kernel-arch
 IMAGE_CREATE_FUNCS:>USE_ramdisk_image = " cpio_mkimage"
-CLASS_DEPENDS:>USE_ramdisk_image = " native:u-boot-tools-mkimage"
+CLASS_DEPENDS:>USE_ramdisk_image = " native:util/mkimage"
 
 cpio_image () {
 	(

--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -180,11 +180,11 @@ do_compile () {
 }
 
 CLASS_DEPENDS += "${KERNEL_UIMAGE_DEPENDS}"
-KERNEL_UIMAGE_DEPENDS = "${@['', 'native:u-boot-tools-mkimage']['${USE_kernel_imagetype}'.startswith('uImage')]}"
+KERNEL_UIMAGE_DEPENDS = "${@['', 'native:util/mkimage']['${USE_kernel_imagetype}'.startswith('uImage')]}"
 
 CLASS_FLAGS += "kernel_uimage \
     kernel_uimage_entrypoint kernel_uimage_loadaddress kernel_uimage_name"
-KERNEL_UIMAGE_DEPENDS:USE_kernel_uimage = "native:u-boot-tools-mkimage"
+KERNEL_UIMAGE_DEPENDS:USE_kernel_uimage = "native:util/mkimage"
 DEFAULT_USE_kernel_uimage = "0"
 DEFAULT_USE_kernel_uimage_name = "${DISTRO}/${PV}/${MACHINE}"
 

--- a/classes/sdk-image.oeclass
+++ b/classes/sdk-image.oeclass
@@ -82,7 +82,7 @@ DEFAULT_USE_sdk_uboot_mkimage = "1"
 RDEPENDS_SDK += "${RDEPENDS_SDK_UBOOT_MKIMAGE}"
 RDEPENDS_SDK_UBOOT_MKIMAGE = ""
 RDEPENDS_SDK_UBOOT_MKIMAGE:USE_sdk_uboot_mkimage = "${UBOOT_MKIMAGE}"
-UBOOT_MKIMAGE = "host:u-boot-tools-mkimage"
+UBOOT_MKIMAGE = "host:util/mkimage"
 UBOOT_MKIMAGE:HOST_OS_mingw32 = ""
 
 CLASS_FLAGS += "sdk_archive_formats sdk_archive_tar_ext"

--- a/classes/u-boot.oeclass
+++ b/classes/u-boot.oeclass
@@ -58,7 +58,7 @@ RECIPE_TYPES = "machine"
 
 inherit c make kernel-arch
 
-CLASS_DEPENDS += "native:u-boot-tools-mkimage"
+CLASS_DEPENDS += "native:util/mkimage"
 
 # Why bother?  U-Boot will most likely stay broken for parallel builds
 PARALLEL_MAKE = ""

--- a/classes/uimage-fit.oeclass
+++ b/classes/uimage-fit.oeclass
@@ -19,7 +19,7 @@ SRC_URI += "file://${USE_fit_file}"
 
 do_compile[postfuncs] += "do_compile_fit"
 
-CLASS_DEPENDS += "native:u-boot-tools-mkimage"
+CLASS_DEPENDS += "native:util/mkimage"
 
 do_compile_fit() {
    [ -e ${SRCDIR}/${USE_fit_file} ] && mv ${SRCDIR}/${USE_fit_file} ${S}/.


### PR DESCRIPTION
Allows different naming of u-boot-tools recipe and other provides of the
util. This patch removes all hardcoded u-boot-tools-* .