### PR TITLE
kernel.oeclass: fix for building out-of-tree module on x86_32

### DIFF
--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -313,7 +313,7 @@ do_install_kernel () {
     mkdir -p ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
     cp -fR arch/${KERNEL_ARCH}/lib ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
     cp -fR arch/${KERNEL_ARCH}/include ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
-    cp -fR arch/${KERNEL_ARCH}/Makefile ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
+    cp -fR arch/${KERNEL_ARCH}/Makefile* ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
     for d in arch/${KERNEL_ARCH}/mach-*/include ; do
         if [ "$d" = "arch/${KERNEL_ARCH}/mach-*/include" ] ; then
             continue


### PR DESCRIPTION
The do_install_kernel rule apparently tries to copy a minimal set of
files allowing building out-of-tree modules. However, when trying to
compile a module against kernel 4.1.15, I hit:

  arch/x86/Makefile:66: arch/x86/Makefile_32.cpu: No such file or directory

I think this is related to kernel commit
a436bb7b806383ae0593cab53d17fc9676270cd3 (kbuild: use relative path
more to include Makefile), which changed the line including
Makefile_32.cpu like this:

-        include $(srctree)/arch/x86/Makefile_32.cpu
+        include arch/x86/Makefile_32.cpu

This is a band aid-and-chewing gum patch which fixes the problem for
me, but I'm sure there is a better and less fragile solution.