### PR TITLE
gcc, glibc: fix bootstrapping -fstack-protector detection and use

### DIFF
--- a/recipes/gcc/gcc-bootstrap.inc
+++ b/recipes/gcc/gcc-bootstrap.inc
@@ -26,7 +26,8 @@ do_configure() {
 	--disable-libatomic \
 	--disable-libitm \
 	--disable-libsanitizer \
-	--disable-libquadmath
+	--disable-libquadmath \
+	--with-glibc-version="${USE_glibc_min_version}"
 }
 
 do_compile_targets = "all-gcc all-target-libgcc"

--- a/recipes/gcc/gcc-common.inc
+++ b/recipes/gcc/gcc-common.inc
@@ -8,6 +8,9 @@ FILESPATHPKG .= ":gcc-${@'.'.join(d.get('PV').split('.')[:2])}"
 
 inherit make make-vpath c c++
 
+RECIPE_FLAGS += "glibc_min_version"
+DEFAULT_USE_glibc_min_version = "2.22"
+
 DEPENDS += "target-cross:binutils target:gcc-bootstrap-libc-headers"
 DEPENDS += "host:mpc host:mpfr host:gmp host:isl host:cloog"
 DEPENDS += "host:libz"

--- a/recipes/gcc/gcc.inc
+++ b/recipes/gcc/gcc.inc
@@ -28,7 +28,8 @@ do_configure() {
 	--enable-threads=posix \
 	--enable-libstdcxx-time \
 	--disable-libstdcxx-pch \
-	--with-gxx-include-dir=${D_SYSROOT}${target_includedir}/c++
+	--with-gxx-include-dir=${D_SYSROOT}${target_includedir}/c++ \
+	--with-glibc-version="${USE_glibc_min_version}"
 }
 
 inherit libtool

--- a/recipes/glibc/glibc.inc
+++ b/recipes/glibc/glibc.inc
@@ -37,11 +37,6 @@ DEFAULT_USE_toolchain_kernel_version_sdk	= "2.6.32"
 MIN_KERNEL_VERSION = "${USE_toolchain_kernel_version_native}${USE_toolchain_kernel_version_machine}${USE_toolchain_kernel_version_sdk}"
 MIN_KERNEL_VERSION[expand] = "3"
 
-do_configure[prefuncs] += "do_configure_siteinfo"
-do_configure_siteinfo() {
-	echo "libc_cv_ssp=no" > config.cache
-}
-
 EXTRA_OECONF += "\
 	--disable-profile \
 	--with-tls \


### PR DESCRIPTION
The glibc recipe unconditionally disables use of
-fstack-protector. That's a bit unfortunate, because upstream glibc
tries to use that for some security-critical components
(e.g. resolv). It does not enable it for all of glibc, as that would
imply a significant performance loss.

The reason for this disabling is not obvious from the git history, but
it was presumably done as a hack to simply make glibc build (or
rather: link). However, the problem is really in gcc: gcc, at the
linking stage, needs to know whether the target libc has the
infrastructure to support the -fstack-protector instrumentation. But
the autodetect in the configure stage of gcc cannot possibly work when
the target glibc doesn't even exist yet. So we need to make sure that
the configure variable gcc_cv_libc_provides_ssp is set to yes at all
stages (including bootstrap).

Starting with gcc 4.9, gcc's configure supports
--with-glibc-version=M.N which can be used to explicitly set the
target glibc version
(https://gcc.gnu.org/ml/gcc-patches/2013-11/msg00619.html). Ideally,
we should set M.N automagically from the glibc version that we're
actually building, but for now we do something a little less fancy: a
USE flag which can then be overridden from the glibc recipe.

While at it, remove the disabling of -fstack-protector from glibc.