### PR TITLE
Allow override of TMPDIR, IMAGE_DEPLOY_DIR and more

### DIFF
--- a/conf/oelayout.conf
+++ b/conf/oelayout.conf
@@ -2,21 +2,21 @@
 # Internal OE-core directory layout
 #
 
-TMPDIR		 = "${@os.path.realpath('${TOPDIR}/tmp')}"
+TMPDIR		?= "${@os.path.realpath('${TOPDIR}/tmp')}"
 TMPDIR[nohash]	 = True
-CACHEDIR	 = "${TMPDIR}/cache"
+CACHEDIR	?= "${TMPDIR}/cache"
 CACHEDIR[nohash] = True
-SCMDIR		 = "${TMPDIR}/scm"
+SCMDIR		?= "${TMPDIR}/scm"
 SCMDIR[nohash]	 = True
-CVSDIR		 = "${SCMDIR}/cvs"
+CVSDIR		?= "${SCMDIR}/cvs"
 CVSDIR[nohash]	 = True
-SVNDIR		 = "${SCMDIR}/svn"
+SVNDIR		?= "${SCMDIR}/svn"
 SVNDIR[nohash]	 = True
-GITDIR		 = "${SCMDIR}/git"
+GITDIR		?= "${SCMDIR}/git"
 GITDIR[nohash]	 = True
-BZRDIR		 = "${SCMDIR}/bzr"
+BZRDIR		?= "${SCMDIR}/bzr"
 BZRDIR[nohash]	 = True
-HGDIR		 = "${SCMDIR}/hg"
+HGDIR		?= "${SCMDIR}/hg"
 HGDIR[nohash]	 = True
 
 INGREDIENTS	?= "${TOPDIR}/ingredients"
@@ -52,12 +52,12 @@ BUILD_SYSROOT		 = "${STAGE_DIR}/native"
 HOST_SYSROOT		 = "${STAGE_DIR}/${HOST_TYPE}"
 TARGET_SYSROOT		 = "${STAGE_DIR}/${TARGET_TYPE}"
 
-IMAGE_DEPLOY_DIR	 = "${TMPDIR}/images"
+IMAGE_DEPLOY_DIR	?= "${TMPDIR}/images"
 IMAGE_DEPLOY_DIR[nohash] = True
-PACKAGE_DEPLOY_DIR 	 = "${TMPDIR}/packages"
+PACKAGE_DEPLOY_DIR	?= "${TMPDIR}/packages"
 PACKAGE_DEPLOY_DIR[nohash] = True
 
-PREBAKE_CACHE_DIR 	      = "${TMPDIR}/prebake"
+PREBAKE_CACHE_DIR	?= "${TMPDIR}/prebake"
 PREBAKE_CACHE_DIR[nohash] = True
 
 # Recipe directory layout


### PR DESCRIPTION
Change to weak assignment, allowing override of a number of basic dir
variables using ENV variables.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>