### PR TITLE
lib/oelite: Fix false skipping of REBUILD marked recipes

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -454,7 +454,9 @@ class OEliteBaker:
         if url_prefix is not None:
             info("Trying to use prebakes from url: %s"%(url_prefix))
         for package in depend_packages:
-            # FIXME: skip this package if it is to be rebuild
+            recipe = self.cookbook.get_recipe(package=package)
+            if recipe.get("REBUILD") == "1":
+                continue
             prebake = self.find_prebaked_package(package)
             if prebake:
                 self.runq.set_package_filename(package, prebake,


### PR DESCRIPTION
This fixes some cases where recipes marked with REBUILD="1" (fx. anything
inheriting image.oeclass) were not rebuild.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>