### PR TITLE
image: Package blacklist for rstage

### DIFF
--- a/classes/image.oeclass
+++ b/classes/image.oeclass
@@ -72,8 +72,9 @@ def do_rstage(d):
     else:
         def get_dstdir(cwd, package):
             return cwd
+    blacklisted_packages = (d.get("RSTAGE_BLACKLIST_PACKAGES") or "").split()
     retval = set_stage(d, "__rstage", "RSTAGE_FIXUP_FUNCS", get_dstdir,
-                       d.get("RSTAGE_DIR") + ".unpack")
+                       d.get("RSTAGE_DIR") + ".unpack", blacklisted_packages)
     metadir = d.getVar("metadir", True).lstrip("/")
     if os.path.exists(metadir):
         shutil.rmtree(metadir)

--- a/classes/stage.oeclass
+++ b/classes/stage.oeclass
@@ -23,7 +23,8 @@ def do_stage(d):
 
 set_stage[emit] += "do_stage"
 
-def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir):
+def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir,
+              blacklisted_packages=[]):
     import tempfile
     from oelite.util import TarFile
     from oebakery import debug, info, warn, err, die
@@ -68,6 +69,8 @@ def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir):
     staged_packages = []
     for filename in stage_files:
         package = stage[filename]
+        if str(package) in blacklisted_packages:
+            continue
         if not os.path.isfile(filename):
             die("could not find stage file: %s"%(filename))
         dstdir = get_dstdir(cwd, package)


### PR DESCRIPTION
This add support for blacklisting of packages for rstage, which has been
used since at least 2011 to handle differences between differences in
dependencies in rootfs and initramfs.

Ideally, we should have support for using multiple distros (or something
like that), so that initramfs and rootfs could use different distro
configuration, while still being build as a single image.

But until then, this seems like the best solution we have been able to
come up with, so let's get it merged.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>