### PR TITLE
binconfig.oeclass: fix file globbing in do_install_binconfig_fixup

### DIFF
--- a/classes/binconfig.oeclass
+++ b/classes/binconfig.oeclass
@@ -13,6 +13,9 @@ do_install[postfuncs] += "do_install_binconfig_fixup"
 do_install_binconfig_fixup[dirs] = "${D}"
 
 def do_install_binconfig_fixup(d):
+    import os
+    os.chdir(d.get("D"))
+
     binconfig_files = []
     for pattern in d.get("BINCONFIG_GLOB").split():
         binconfig_files += glob.glob(pattern.lstrip("/"))


### PR DESCRIPTION
When running glob.glob() in python, the call does a search on the file
system to expand wildcards to matching files. This failed in binconfig
due to globing relative to the source directory and the removal of
heading slashes (i.e. '/usr/bin/*-config' -> 'usr/bin/*-config'.

Fix this by changing working directory prior to the globing, so that the
search is done relative to the install directory.