### PR TITLE
fakeroot: add correct dependencies.

### DIFF
--- a/recipes/fakeroot/fakeroot.inc
+++ b/recipes/fakeroot/fakeroot.inc
@@ -11,6 +11,7 @@ HOMEPAGE = "http://fakeroot.alioth.debian.org"
 inherit autotools
 
 RECIPE_TYPES="native"
+DEPENDS = "native:libacl1-dev"
 
 require conf/fetch/debian.conf
 SRC_URI = "${DEBIAN_MIRROR}/main/f/fakeroot/fakeroot_${PV}.orig.tar.bz2"


### PR DESCRIPTION
fakeroot depends on host libacl1-dev to set correct permissions on
files/folders.

If libacl1-dev is not available, all folders/files are root-only
writable.