### PR TITLE
cookbook: Avoid writing none complete cache file by not writing any thing at all

### DIFF
--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -563,6 +563,9 @@ class CookBook(Mapping):
             if recipe_meta is False:
                 print "ERROR: parsing %s failed"%(filename)
                 return False
+            if not recipe_meta:
+                # recipe not compatible with our usage - pretend we've cached it
+                return True
             recipes = {}
             is_cacheable = True
             for recipe_type in recipe_meta:


### PR DESCRIPTION
None complete cache files were made in case a recipe wasn't compatible
with our setup. I.e. if a COMPATIBLE_IF_FLAG was set but the corresponding
'compatible' USE-flag wasn't defined.

Reading incomplete cache files resulted in not relevant warning-noice