### PR TITLE
base-version: Removed gcc-cross-config. It not present with never toolchain

### DIFF
--- a/recipes/base-version/base-version.oe
+++ b/recipes/base-version/base-version.oe
@@ -61,25 +61,6 @@ do_install_basefiles_buildtime () {
 		${D}${sysconfdir}/${USE_basefiles_buildtime}
 }
 
-RECIPE_FLAGS += "basefiles_cross_config"
-DEPENDS:>USE_basefiles_cross_config = " cross:gcc-config"
-BASE_VERSION_POSTFUNCS:>USE_basefiles_cross_config = " do_install_basefiles_cross_config"
-do_install_basefiles_cross_config[expand] = 3
-do_install_basefiles_cross_config () {
-	install -m 0755 -d ${D}${sysconfdir}
-        if [ ! -r "${STAGE_DIR}/cross/gcc-config" ]; then
-                echo "Error unable to read ${STAGE_DIR}/cross/gcc-config"
-                return 1
-        fi
-	sed -n -e '/NG version/ p' -e 's/#.*//' -e '/PKGVERSION/ d' \
-		-e '/VERSION/ p' ${STAGE_DIR}/cross/gcc-config > \
-		${SRCDIR}/${USE_basefiles_cross_config}
-
-	install -m 0755 -d ${D}${sysconfdir}
-	install -m 0644 ${SRCDIR}/${USE_basefiles_cross_config} \
-		${D}${sysconfdir}/${USE_basefiles_cross_config}
-}
-
 export BUILD_TAG
 RECIPE_FLAGS += "basefiles_buildtag"
 BASE_VERSION_POSTFUNCS:>USE_basefiles_buildtag = " do_install_basefiles_buildtag"


### PR DESCRIPTION
Contained the ctng configuration before. Since we no longer use ctng,
remove it

Signed-off-by: Christian Sørensen <christian.braunersorensen@prevas.dk>