### PR TITLE
Faster metadata hashing

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -309,8 +309,7 @@ class OEliteBaker:
                 die("No such task: %s: %s"%(thing, e.__str__()))
             except oebakery.FatalError, e:
                 die("Failed to add %s:%s to runqueue"%(thing, task))
-        if self.debug:
-            timing_info("Building dependency tree", start)
+        timing_info("Building dependency tree", start)
 
         # Generate recipe dependency graph
         recipes = set([])
@@ -432,8 +431,7 @@ class OEliteBaker:
         oelite.util.progress_info("Calculating task metadata hashes",
                                   total, count)
 
-        if self.debug:
-            timing_info("Calculation task metadata hashes", start)
+        timing_info("Calculation task metadata hashes", start)
 
         if count != total:
             print ""

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -249,7 +249,7 @@ class OEliteBaker:
             meta = recipe.meta
 
         #meta.dump(pretty=False, nohash=False, flags=True,
-        #          ignore_flags=("filename", "lineno"),
+        #          ignore_flags=re.compile("filename|lineno"),
         meta.dump(pretty=True, nohash=(not self.options.nohash),
                   only=(self.things_todo[1:] or None))
 

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -46,6 +46,7 @@ class DictMeta(MetaData):
             self.dict["__flag_index"] = {}
             for flag in self.INDEXED_FLAGS:
                 self.dict["__flag_index"][flag] = set([])
+        self.expand_cache_filled = False
         super(DictMeta, self).__init__(meta=meta)
         return
 
@@ -218,6 +219,12 @@ class DictMeta(MetaData):
         self.expand_cache[var] = (val, deps)
         return (val, deps)
 
+    def _fill_expand_cache(self):
+        if self.expand_cache_filled:
+            return
+        for var in self.keys():
+            self._get(var)
+        self.expand_cache_filled = True
 
     def get_overrides(self):
         return _get_overrides(self)[0]

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -371,7 +371,7 @@ class MetaData(MutableMapping):
         return
 
 
-    builtin_nohash = [
+    builtin_nohash = frozenset([
         "OE_REMOTES",
         "OE_MODULES",
         "OE_ENV_WHITELIST",
@@ -396,7 +396,7 @@ class MetaData(MutableMapping):
         "INCOMPATIBLE_RECIPES",
         "COMPATIBLE_IF_FLAGS",
         "_task_deps",
-    ]
+    ])
 
     builtin_nohash_prefix = [
         "OE_REMOTE_",

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -410,10 +410,10 @@ class MetaData(MutableMapping):
         else:
             eol = "\n"
 
-        var_flags = sorted(self.get_flags(key).items())
+        var_flags = self.get_flags(key)
 
         if flags:
-            for flag,val in var_flags:
+            for flag,val in sorted(var_flags.items()):
                 if flag == "expand":
                     continue
                 if ignore_flags_re and ignore_flags_re.match(flag):
@@ -422,14 +422,14 @@ class MetaData(MutableMapping):
                     continue
                 o.write("%s[%s]=%r\n"%(key, flag, val))
 
-        if self.get_flag(key, "python"): # FIXME: use _flags
+        if var_flags.get("python"):
             func = "python"
-        elif self.get_flag(key, "bash"): # FIXME: use _flags
+        elif var_flags.get("bash"):
             func = "bash"
         else:
             func = None
 
-        expand = self.get_flag(key, "expand") # FIXME: use _flags
+        expand = var_flags.get("expand")
         if expand is not None:
             expand = int(expand)
         elif func == "python":
@@ -460,7 +460,7 @@ class MetaData(MutableMapping):
             o.write("%s() {\n%s}%s"%(key, val, eol))
             return
 
-        if pretty and self.get_flag(key, "export"):
+        if pretty and var_flags.get("export"):
             o.write("export ")
 
         o.write("%s=%s%s"%(key, repr(val), eol))

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -404,7 +404,7 @@ class MetaData(MutableMapping):
     ]
 
     def dump_var(self, key, o=sys.__stdout__, pretty=True, dynvars={},
-                 flags=False, ignore_flags=None):
+                 flags=False, ignore_flags_re=None):
         if pretty:
             eol = "\n\n"
         else:
@@ -413,12 +413,10 @@ class MetaData(MutableMapping):
         var_flags = sorted(self.get_flags(key).items())
 
         if flags:
-            if ignore_flags:
-                ignore_flags = re.compile("|".join(ignore_flags))
             for flag,val in var_flags:
                 if flag == "expand":
                     continue
-                if ignore_flags and ignore_flags.match(flag):
+                if ignore_flags_re and ignore_flags_re.match(flag):
                     continue
                 if pretty and flag in ("python", "bash", "export"):
                     continue
@@ -470,7 +468,7 @@ class MetaData(MutableMapping):
 
 
     def dump(self, o=sys.__stdout__, pretty=True, nohash=False, only=None,
-             flags=False, ignore_flags=None):
+             flags=False, ignore_flags_re=None):
 
         dynvars = []
         for varname in ("WORKDIR", "TOPDIR", "DATETIME",
@@ -496,7 +494,7 @@ class MetaData(MutableMapping):
                         break
                 if nohash_prefixed:
                     continue
-            self.dump_var(key, o, pretty, dynvars, flags, ignore_flags)
+            self.dump_var(key, o, pretty, dynvars, flags, ignore_flags_re)
 
 
     def get_function(self, name):
@@ -508,7 +506,7 @@ class MetaData(MutableMapping):
             return oelite.function.ShellFunction(self, name)
 
 
-    def signature(self, ignore_flags=("__", "emit$", "omit$", "filename"),
+    def signature(self, ignore_flags_re=re.compile("|".join(("__", "emit$", "omit$", "filename"))),
                   force=False, dump=None):
         import hashlib
 
@@ -537,13 +535,13 @@ class MetaData(MutableMapping):
             assert isinstance(dump, basestring)
             dumper = StringOutput()
             self.dump(dumper, pretty=False, nohash=False,
-                      flags=True, ignore_flags=ignore_flags)
+                      flags=True, ignore_flags_re=ignore_flags_re)
             dumpdir = os.path.dirname(dump)
             if dumpdir and not os.path.exists(dumpdir):
                 os.makedirs(dumpdir)
             open(dump, "w").write(dumper.blob)
         self.dump(hasher, pretty=False, nohash=False,
-                  flags=True, ignore_flags=ignore_flags)
+                  flags=True, ignore_flags_re=ignore_flags_re)
 
         self._signature = str(hasher)
         return self._signature

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -151,6 +151,7 @@ class OEliteTask:
     def meta(self):
         if self._meta is not None:
             return self._meta
+        self.recipe.meta._fill_expand_cache()
         meta = self.recipe.meta.copy()
         # Filter meta-data, enforcing restrictions on which tasks to
         # emit vars to and not including other task functions.


### PR DESCRIPTION
We spend longer on the initial part of 'oe bake' than we should; that's particularly annoying when there's actually nothing to do. These are just a few low-hanging fruits, and I freely admit that the last patch is really ugly, but OTOH that's what gives the largest improvement.

Master + the just the first patch:

$ time oe bake gnutls
Adding recipes to cookbook: 233 / 233 [100 %]
Building dependency tree time 1.114 seconds
Calculating task metadata hashes: 405 / 405 [100 %]
Calculation task metadata hashes time 6.266 seconds
Nothing to do

real    0m9.760s
user    0m9.500s
sys     0m0.244s

With all these:

$ time oe bake gnutls
Adding recipes to cookbook: 233 / 233 [100 %]
Building dependency tree time 1.117 seconds
Calculating task metadata hashes: 405 / 405 [100 %]
Calculation task metadata hashes time 3.984 seconds
Nothing to do

real    0m7.393s
user    0m7.180s
sys     0m0.196s

We're still spending more than half the time on the hash computations, so there's probably more to get from there.