### PR TITLE
Memory use reduction, v4

### DIFF
--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -32,6 +32,7 @@ class CookBook(Mapping):
         self.db = sqlite.connect(":memory:")
         if not self.db:
             raise Exception("could not create in-memory sqlite db")
+        self.db.text_factory = str
         self.dbc = self.db.cursor()
         self.init_db()
         self.recipes = {}

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -94,7 +94,7 @@ class DictMeta(MetaData):
 
     def trim_expand_cache(self, var):
         for (cached_var, (cached_val, deps)) in self.expand_cache.items():
-            if cached_var == var or var in deps:
+            if cached_var == var or (deps and var in deps):
                 # FIXME: is it safe to delete from the dict we are iterating ?
                 del self.expand_cache[cached_var]
         return
@@ -178,7 +178,10 @@ class DictMeta(MetaData):
         override_dep = None
         if "__overrides" in self.dict[var]:
             current_overrides, override_dep = self._get_overrides()
-            override_dep.add("OVERRIDES")
+            if override_dep:
+                override_dep.add("OVERRIDES")
+            else:
+                override_dep = set(["OVERRIDES"])
             var_overrides = self.dict[var]["__overrides"]['']
             append_overrides = self.dict[var]["__overrides"]['>']
             prepend_overrides = self.dict[var]["__overrides"]['<']
@@ -234,6 +237,8 @@ class DictMeta(MetaData):
 
         if override_dep:
             deps = deps.union(override_dep)
+        if not deps:
+            deps = None
         self.expand_cache[var] = (val, deps)
         return (val, deps)
 

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -39,9 +39,9 @@ class DictMeta(MetaData):
 
     def __init__(self, meta=None):
         if isinstance(meta, file):
-            self.dict = cPickle.load(meta)
-            self.expand_cache = cPickle.load(meta)
-            self.__flag_index = cPickle.load(meta)
+            self.dict = copy.deepcopy(cPickle.load(meta))
+            self.expand_cache = copy.deepcopy(cPickle.load(meta))
+            self.__flag_index = copy.deepcopy(cPickle.load(meta))
             meta = None
         elif isinstance(meta, DictMeta):
             self.dict = {}

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -9,6 +9,11 @@ import operator
 import types
 import os
 
+def deepcopy_str(x, memo):
+    return intern(x)
+
+copy._deepcopy_dispatch[str] = deepcopy_str
+
 
 def unpickle(file):
     return DictMeta(meta=file)

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -107,7 +107,7 @@ class DictMeta(MetaData):
 
 
     def weak_set_flag(self, var, flag, val):
-        if not var in self.dict.keys() or not flag in self.dict[var].keys():
+        if not var in self.dict or not flag in self.dict[var]:
             self.set_flag(var, flag, val)
 
 

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -230,7 +230,7 @@ class DictMeta(MetaData):
         return _get_overrides(self)[0]
 
     def _get_overrides(self):
-        overrides = self._get("OVERRIDES", 2)
+        overrides = self._get("OVERRIDES", PARTIAL_EXPANSION)
         filtered = []
         for override in overrides[0].split(":"):
             if not "${" in override:

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -267,7 +267,7 @@ class MetaData(MutableMapping):
         expanded_string = ""
         string_ptr = 0
         for var_match in var_re.finditer(string):
-            var = var_match.group(0)[2:-1]
+            var = intern(var_match.group(0)[2:-1])
             (val, recdeps) = self._get(var)
             if val is None:
                 if method == CLEAN_EXPANSION:
@@ -296,7 +296,7 @@ class MetaData(MutableMapping):
                 deps = deps.union(recdeps)
             self.expand_stack.pop()
         #print "returning expanded string %s"%(repr(expanded_string))
-        return (expanded_string, deps)
+        return (intern(expanded_string), deps)
 
 
     def append(self, var, value, separator=""):

--- a/lib/oelite/parse/oelex.py
+++ b/lib/oelite/parse/oelex.py
@@ -60,6 +60,7 @@ def t_VARNAME(t):
     #r'[a-zA-Z][a-zA-Z0-9_\-\${}\+\.]*'
     r'[a-zA-Z_][a-zA-Z0-9_\-\${}\+\.]*'
     #r'[a-zA-Z_][a-zA-Z0-9_\-\${}/\+\.]*'
+    t.value = intern(t.value)
     t.type = reserved.get(t.value, 'VARNAME')
     if t.type == 'VARNAME':
         pass
@@ -73,19 +74,19 @@ def t_VARNAME(t):
 
 def t_OVERRIDE(t):
     r':[a-zA-Z0-9\-_]+'
-    t.value = ('', t.value[1:])
+    t.value = ('', intern(t.value[1:]))
     return t
 
 def t_OVERRIDE2(t):
     r':[\>\<][a-zA-Z0-9\-_]+'
     t.type = 'OVERRIDE'
-    t.value = (t.value[1], t.value[2:])
+    t.value = (intern(t.value[1]), intern(t.value[2:]))
     return t
 
 def t_FLAG(t):
     r'\[[a-zA-Z_][a-zA-Z0-9_]*\]'
     #t.type = reserved.get(t.value, 'FLAG')
-    t.value = t.value[1:-1]
+    t.value = intern(t.value[1:-1])
     return t
 
 def t_APPEND(t):
@@ -143,6 +144,7 @@ t_def_ignore = ' \t'
 def t_def_FUNCSTART(t):
     r'[a-zA-Z_][a-zA-Z0-9_]*'
     t.type = "VARNAME"
+    t.value = intern(t.value)
     return t
 
 def t_def_ARGSTART(t):
@@ -436,6 +438,7 @@ def t_dquote_STRING(t):
     t.lexer.lineno += t.value.count('\n')
     t.value = re.sub(r"(\s+\\\n(\s+)?)|(\\\n\s+)", " ", t.value)
     t.value = t.value.decode("string-escape")
+    t.value = intern(t.value)
     return t
 
 def t_dquote_QUOTE(t):
@@ -459,6 +462,7 @@ def t_squote_STRING(t):
     t.lexer.lineno += t.value.count('\n')
     t.value = re.sub(r"(\s+\\\n(\s+)?)|(\\\n\s+)", " ", t.value)
     t.value = t.value.decode("string-escape")
+    t.value = intern(t.value)
     return t
 
 def t_squote_QUOTE(t):

--- a/lib/oelite/parse/oeparse.py
+++ b/lib/oelite/parse/oeparse.py
@@ -103,7 +103,7 @@ class OEParser(object):
     
     def p_export_variable(self, p):
         '''export_variable : EXPORT VARNAME'''
-        p[0] = self.meta.expand(p[2])
+        p[0] = intern(self.meta.expand(p[2]))
         self.meta.set_flag(p[0], "export", "1")
         return
 
@@ -144,7 +144,7 @@ class OEParser(object):
 
     def p_string_value2(self, p):
         '''string_value : STRING string_value'''
-        p[0] = p[1] + p[2]
+        p[0] = intern(p[1] + p[2])
         return
 
     def p_simple_var_assignment(self, p):


### PR DESCRIPTION
This is morally identical to the patches in PR #131, but rebased on top of current master (to fix up some conflicts with PR #132 which was merged in the meantime). Submitting again hoping that the openssl issue is now gone. Original pull request text:

These patches reduce the memory footprint of oelite by about 35%, measured immediately after the task metadata hash computation is done. They do not have any measurable effect on the run time of a "oe bake machine" when machine is already fully built (see below for details). I do believe that the runtime of an actual build will decrease when the kernel has more RAM (on my machine, on the order of an extra 1.5% of total memory, or about 240MiB) to play with for page cache etc. instead of having it tied up in a process which will mostly never use it again.

The first three patches are not directly related to this goal and could/should go in on their own, but the first (get str objects from sqlite, not unicode) is a prerequisite for some of the following patches, so I included them here.

I cherry-picked these patches to a random customer project and did a full 'rm -rf tmp/ && oe bake machine' to check that I didn't break anything, but obviously I cannot be sure that that would exercise all code paths, so there may certainly be stuff to fix - I do believe that the possible memory savings are worth it, despite whatever pain we may encounter.

So, with machine fully built and everything nicely cached, I watched the memory consumption in top. Before, it peaked at 4.5%, after at 3.0%. This is consistent with the numbers I got from "within" python, using the meliae module to inspect the memory use of all live objects. Timings are

$ time oe bake machine
Adding recipes to cookbook: 301 / 301 [100 %]
Calculating task metadata hashes: 1244 / 1244 [100 %]
Nothing to do

real 0m35.678s
user 0m35.236s
sys 0m0.456s

$ time oe bake machine
Adding recipes to cookbook: 301 / 301 [100 %]
Calculating task metadata hashes: 1244 / 1244 [100 %]
Nothing to do

real 0m35.638s
user 0m35.308s
sys 0m0.344s