### PR TITLE
oelite: runq.py: add an index to the recdepend table

### DIFF
--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -69,6 +69,9 @@ class OEliteRunQueue:
             "package		INTEGER, "
             "parent_package	INTEGER )")
 
+        self.dbc.execute(
+            "CREATE INDEX runq.recdepend_idx ON recdepend (package)"
+        )
         return
 
 


### PR DESCRIPTION
During my "make it faster" efforts, I stumbled on this, which I'm sending by itself since I believe it is highly unlikely to break anything and obviously a huge win.

Creating an index cuts over 75% of the "Building dependency tree
time", from ~6m04s to ~1m29s.