### PR TITLE
classes/binconfig-stage: create destination dirs before symlinking

### DIFF
--- a/classes/binconfig-stage.oeclass
+++ b/classes/binconfig-stage.oeclass
@@ -82,6 +82,9 @@ def binconfig_stage_fixup(d):
             dstlink = os.path.join(
                 stage_dir, cross_type, d.get("stage_bindir").lstrip("/"),
                 os.path.basename(filename))
+            dstdir = os.path.dirname(dstlink)
+            print("creating destination dir: {}".format(dstdir))
+            oelite.util.makedirs(dstdir)
             print "symlinking %s to %s"%(dstlink, srcfile)
             os.symlink(srcfile, dstlink)
 


### PR DESCRIPTION
When staging packages that inherit binconfig, binconfig_stage_fixup() is
called to create a symlink:
./stage/cross/${bindir}/${PN}-config -> ./stage/machine/${bindir}/${PN}-config

When binconfig_stage_fixup() is called the destination directory for the
symlink (./stage/cross/${bindir}) might not exist, in which case the
symlink creating fails. This is the case when the first dependency being
stages uses binconfig-fixup.

Simply fix this by always creating the destination directory before
symlinking.