### PR TITLE
conf/provided: Make default usable again

### DIFF
--- a/conf/provided/all.conf
+++ b/conf/provided/all.conf
@@ -4,5 +4,4 @@ ASSUME_PROVIDED += "\
 native:ruby \
 native:mtd-utils-mkfs-jffs2 \
 native:libiconv \
-native:libacl1-dev \
 "

--- a/conf/provided/default.conf
+++ b/conf/provided/default.conf
@@ -10,4 +10,5 @@ native:texinfo native:makeinfo native:doxygen \
 native:texlive-extra-utils native:texlive-latex-extra native:latex-xcolor \
 native:flex native:bison \
 native:wget \
+native:libacl1-dev \
 "


### PR DESCRIPTION
As fakeroot as of 53e6e982456e depends on libacl1-dev, and we do not
have a recipe for this, default is not usable at all without it.

For conf/provided/all.conf, libacl1-dev was added in 367b92d25983b
(although the PR comments suggested that it was moved to another commit).

Signed-off-by: Esben Haabendal <esben@haabendal.dk>