### PR TITLE
gitfetcher: Added git prune origin call before git remote update

### DIFF
--- a/lib/oelite/fetch/git.py
+++ b/lib/oelite/fetch/git.py
@@ -285,5 +285,5 @@ class GitFetcher():
             return oelite.util.shcmd(cmd) is True
         else:
             print "Updating git mirror", path
-            cmd = "git remote update"
+            cmd = "git remote update --prune"
             return oelite.util.shcmd(cmd, dir=path) is True


### PR DESCRIPTION
This was done to avoid the following error:
/build/ingredients/glibc/git/git_sourceware.org_git_glibc.git> git remote update
Fetching origin
From git://sourceware.org/git/glibc
...
error: 'refs/heads/hjl/memcpy' exists; cannot create 'refs/heads/hjl/memcpy/dpdk/master'
 ! [new branch]      hjl/memcpy/dpdk/master -> hjl/memcpy/dpdk/master  (unable to update local ref)
...
error: some local refs could not be updated; try running
 'git remote prune origin' to remove any old, conflicting branches
error: Could not fetch origin
Error: git update failed (required rev could not be fetched)

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>