### PR TITLE
classes/manifest-version: include unannotated tags and abbrev commit id

### DIFF
--- a/classes/manifest-version.oeclass
+++ b/classes/manifest-version.oeclass
@@ -13,7 +13,7 @@ def manifest_version(d):
     os.chdir(d.get("TOPDIR"))
     version = None
     if os.path.exists(".git"):
-        cmd = subprocess.Popen(["git", "describe", "--dirty", "--always"],
+        cmd = subprocess.Popen(["git", "describe", "--dirty", "--always", "--tags"],
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         version = cmd.communicate()[0].strip()
         if cmd.returncode != 0:

--- a/classes/manifest-version.oeclass
+++ b/classes/manifest-version.oeclass
@@ -13,7 +13,7 @@ def manifest_version(d):
     os.chdir(d.get("TOPDIR"))
     version = None
     if os.path.exists(".git"):
-        cmd = subprocess.Popen(["git", "describe", "--dirty", "--always", "--tags"],
+        cmd = subprocess.Popen(["git", "describe", "--dirty", "--always", "--tags", "--long"],
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         version = cmd.communicate()[0].strip()
         if cmd.returncode != 0:


### PR DESCRIPTION
Using unannotated tags leads to "wrong" manifest versions (i.e. the last
annotated tags instead of the latest unannotated tag).

Including the abbrev commit id makes it possible to backtrack a commit if the
tag is overwritten.
