### PR TITLE
auto-package-libs.oeclass: allow configuring libprefix

### DIFF
--- a/classes/auto-package-libs.oeclass
+++ b/classes/auto-package-libs.oeclass
@@ -33,6 +33,7 @@ AUTO_PACKAGE_LIBS ?= ""
 AUTO_PACKAGE_LIBS_LIBDIR ?= "${libdir} ${sharedlibdir}"
 AUTO_PACKAGE_LIBS_PKGPREFIX ?= "lib"
 AUTO_PACKAGE_LIBS_PROVIDEPREFIX ?= "lib"
+AUTO_PACKAGE_LIBS_LIBPREFIX ?= "lib"
 AUTO_PACKAGE_LIBS_DEV_DEPENDS ?= ""
 AUTO_PACKAGE_LIBS_DEV_RDEPENDS ?= ""
 AUTO_PACKAGE_LIBS_DEPENDS ?= ""
@@ -77,7 +78,7 @@ def auto_package_libs (d):
         if len(libdir) > 5:
             bb.fatal("invalid libdir in AUTO_PACKAGE_LIBS_LIBDIR: %s"%(libdir))
         if len(libdir) < 2:
-            libdir.append("lib")
+            libdir.append(d.get("AUTO_PACKAGE_LIBS_LIBPREFIX"))
         if len(libdir) < 3:
             libdir.append([""])
         else:


### PR DESCRIPTION
Currently, one could achieve rougly the same thing by overriding
AUTO_PACKAGE_LIBS_LIBDIR, setting it to e.g. "${libdir}:myprefix
${sharedlibdir}:myprefix", but it's a lot more convenient to be able
to set the default prefix independently from the libdirs.

The use case is e.g. libunwind, which generates libraries
libunwind.so, libunwind-setjmp.so, libunwind-ptrace.so,
libunwind-coredump.so etc. Rather than making AUTO_PACKAGE_LIBS
contain "unwind-setjmp unwind-ptrace" with corresponding packages
"libunwind-libunwind-setjmp" etc, it's more convenient to set both
PROVIDEPREFIX and LIBPREFIX to "${PN}-" and PKG_PREFIX to "", and then
just list the shorter names "setjmp ptrace" etc. in
AUTO_PACKAGE_LIBS. That way, we get a package "libunwind-ptrace" which
provides "libunwind-ptrace.so".

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>