### PR TITLE
RFC: run tasks in parallel

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -577,7 +577,7 @@ class OEliteBaker:
             count += 1
             debug("")
             debug("Preparing %s"%(task))
-            task.prepare(self.runq)
+            task.prepare()
             meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -576,10 +576,17 @@ class OEliteBaker:
 
         oven = OEliteOven(self, 8)
         try:
-            while True:
+            while oven.count < oven.total:
                 pending += self.runq.get_runabletasks()
-                if not pending:
-                    break
+                if not pending or oven.capacity <= 0:
+                    # If we have no runable tasks and nothing in the
+                    # oven, some tasks must have failed.
+                    if not oven.currently_baking():
+                        break
+                    # Gotta wait for some task to finish. That may
+                    # make some new task eligible.
+                    oven.wait_any(False)
+                    continue
                 task = pending.pop()
                 oven.start(task)
                 oven.wait_task(False, task)

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -565,8 +565,6 @@ class OEliteBaker:
                     info("Maybe next time")
                     return 0
 
-        self.backup_stdio()
-
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
         task = self.runq.get_runabletask()
@@ -606,16 +604,6 @@ class OEliteBaker:
                         else:
                             print ''.join(fin.readlines()[-self.debug_loglines:])
         return exitcode
-
-    def backup_stdio(self):
-        self.real_stdin = os.dup(sys.stdin.fileno())
-        self.real_stdout = os.dup(sys.stdout.fileno())
-        self.real_stderr = os.dup(sys.stderr.fileno())
-
-    def restore_stdio(self):
-        os.dup2(self.real_stdin, sys.stdin.fileno())
-        os.dup2(self.real_stdout, sys.stdout.fileno())
-        os.dup2(self.real_stderr, sys.stderr.fileno())
 
     def setup_tmpdir(self):
 

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -589,7 +589,12 @@ class OEliteBaker:
                     continue
                 task = pending.pop()
                 oven.start(task)
-                oven.wait_task(False, task)
+                # After starting a task, always do an immediate poll -
+                # if it was a synchronous task, it is already done by
+                # the time oven.start() returns, so it might as well get
+                # removed from the oven and its dependents made
+                # eligible.
+                oven.wait_task(True, task)
         finally:
             oven.wait_all(False)
 

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -567,6 +567,8 @@ class OEliteBaker:
 
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
+        #
+        # FIXME: add back support for options.fake_build
         start = datetime.datetime.now()
         total = self.runq.number_of_tasks_to_build()
         count = 0
@@ -585,7 +587,7 @@ class OEliteBaker:
             meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()
-            if self.options.fake_build or task.run():
+            if task.run():
                 task.build_done(self.runq.get_task_buildhash(task))
                 self.runq.mark_done(task)
             else:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -565,6 +565,8 @@ class OEliteBaker:
                     info("Maybe next time")
                     return 0
 
+        self.backup_stdio()
+
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
         task = self.runq.get_runabletask()
@@ -605,6 +607,15 @@ class OEliteBaker:
                             print ''.join(fin.readlines()[-self.debug_loglines:])
         return exitcode
 
+    def backup_stdio(self):
+        self.real_stdin = os.dup(sys.stdin.fileno())
+        self.real_stdout = os.dup(sys.stdout.fileno())
+        self.real_stderr = os.dup(sys.stderr.fileno())
+
+    def restore_stdio(self):
+        os.dup2(self.real_stdin, sys.stdin.fileno())
+        os.dup2(self.real_stdout, sys.stdout.fileno())
+        os.dup2(self.real_stderr, sys.stderr.fileno())
 
     def setup_tmpdir(self):
 

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -3,6 +3,7 @@ from oebakery import die, err, warn, info, debug
 from oelite import *
 from recipe import OEliteRecipe
 from runq import OEliteRunQueue
+from oven import OEliteOven
 import oelite.meta
 import oelite.util
 import oelite.arch
@@ -570,34 +571,24 @@ class OEliteBaker:
         #
         # FIXME: add back support for options.fake_build
         start = datetime.datetime.now()
-        total = self.runq.number_of_tasks_to_build()
-        count = 0
         exitcode = 0
         pending = []
-        failed_task_list = []
-        while True:
-            pending += self.runq.get_runabletasks()
-            if not pending:
-                break
-            task = pending.pop()
-            count += 1
-            debug("")
-            debug("Preparing %s"%(task))
-            task.prepare()
-            info("Running %d / %d %s"%(count, total, task))
-            task.build_started()
-            if task.run():
-                task.build_done(self.runq.get_task_buildhash(task))
-                self.runq.mark_done(task)
-            else:
-                err("%s failed"%(task))
-                failed_task_list.append(task)
-                task.build_failed()
-                # FIXME: support command-line option to abort on first
-                # failed task
+
+        oven = OEliteOven(self, 8)
+        try:
+            while True:
+                pending += self.runq.get_runabletasks()
+                if not pending:
+                    break
+                task = pending.pop()
+                oven.start(task)
+                oven.wait_task(False, task)
+        finally:
+            oven.wait_all(False)
+
         oelite.util.timing_info("Build", start)
 
-        for task in failed_task_list:
+        for task in oven.failed_tasks:
             exitcode = 1
             print "\nERROR: %s failed  %s"%(task,task.logfn)
             if self.debug_loglines:
@@ -691,5 +682,3 @@ class OEliteBaker:
         if path.startswith(topdir):
             topdir = path[len(topdir)+1:]
         return topdir
-
-

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -584,7 +584,6 @@ class OEliteBaker:
             debug("")
             debug("Preparing %s"%(task))
             task.prepare()
-            meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()
             if task.run():

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -591,22 +591,21 @@ class OEliteBaker:
                 self.runq.mark_done(task)
             else:
                 err("%s failed"%(task))
-                exitcode = 1
                 failed_task_list.append(task)
                 task.build_failed()
                 # FIXME: support command-line option to abort on first
                 # failed task
         oelite.util.timing_info("Build", start)
 
-        if exitcode:
-             for task in failed_task_list:
-                print "\nERROR: %s failed  %s"%(task,task.logfn)
-                if self.debug_loglines:
-                    with open(task.logfn, 'r') as fin:
-                        if self.debug_loglines < 0:
-                            print fin.read()
-                        else:
-                            print ''.join(fin.readlines()[-self.debug_loglines:])
+        for task in failed_task_list:
+            exitcode = 1
+            print "\nERROR: %s failed  %s"%(task,task.logfn)
+            if self.debug_loglines:
+                with open(task.logfn, 'r') as fin:
+                    if self.debug_loglines < 0:
+                        print fin.read()
+                    else:
+                        print ''.join(fin.readlines()[-self.debug_loglines:])
         return exitcode
 
     def setup_tmpdir(self):

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -567,13 +567,17 @@ class OEliteBaker:
 
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
-        task = self.runq.get_runabletask()
         start = datetime.datetime.now()
         total = self.runq.number_of_tasks_to_build()
         count = 0
         exitcode = 0
+        pending = []
         failed_task_list = []
-        while task:
+        while True:
+            pending += self.runq.get_runabletasks()
+            if not pending:
+                break
+            task = pending.pop()
             count += 1
             debug("")
             debug("Preparing %s"%(task))
@@ -591,7 +595,6 @@ class OEliteBaker:
                 task.build_failed()
                 # FIXME: support command-line option to abort on first
                 # failed task
-            task = self.runq.get_runabletask()
         oelite.util.timing_info("Build", start)
 
         if exitcode:

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -34,6 +34,10 @@ class OEliteFunction(object):
         return "OEliteFunction(%s)"%(self.var)
 
     def run(self, cwd):
+        self.start(cwd)
+        return self.wait(False)
+
+    def start(self, cwd):
         # Change directory
         old_cwd = os.getcwd()
         os.chdir(cwd)
@@ -45,18 +49,24 @@ class OEliteFunction(object):
             umask = int(self.meta.get("DEFAULT_UMASK"), 8)
         old_umask = os.umask(umask)
         try:
-            return self()
+            self._start()
         finally:
             # Restore directory
             os.chdir(old_cwd)
             # Restore umask
             os.umask(old_umask)
 
+    def _start(self):
+        self.result = self()
+
+    def wait(self, poll=False):
+        return self.result
+
 
 class NoopFunction(OEliteFunction):
 
-    def run(self, cwd):
-        return True
+    def start(self, cwd):
+        self.result = True
     
 
 class PythonFunction(OEliteFunction):

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -67,7 +67,7 @@ class NoopFunction(OEliteFunction):
 
     def start(self, cwd):
         self.result = True
-    
+
 
 class PythonFunction(OEliteFunction):
 
@@ -129,32 +129,43 @@ class PythonFunction(OEliteFunction):
 class ShellFunction(OEliteFunction):
 
     def __init__(self, meta, var, name=None, tmpdir=None):
+        self.result = None
         super(ShellFunction, self).__init__(meta, var, name, tmpdir)
         return
 
-    def runscript(self, cmd):
-        cmdstr = cmd
+    def wait(self, poll):
+        if self.result is not None:
+            return self.result
+        if poll:
+            ret = self.subprocess.poll()
+        else:
+            ret = self.subprocess.wait()
+        if ret is None:
+            return None
+        if ret == 0:
+            self.result = True
+        else:
+            self.result = False
+            print "Error: Command failed: %r: %d"%(self.cmdstr, ret)
+        return self.result
+
+
+    def startscript(self, cmd):
+        self.cmdstr = cmd
         cmdname = cmd.split(None, 1)[0]
 
-        print '> %s'%(cmdstr,)
+        print '> %s'%(cmd,)
 
         try:
-            retval = None
-            returncode = subprocess.call(cmd, stdin=sys.stdin, shell=True)
-            if returncode == 0:
-                retval = True
-            else:
-                print "Error: Command failed: %r: %d"%(cmdstr, returncode)
+            self.subprocess = subprocess.Popen(cmd, stdin=sys.stdin, shell=True)
         except OSError, e:
             if e.errno == 2:
                 print "Error: Command not found:", cmdname
             else:
-                print "Error: Command failed: %r"%(cmdstr)
+                print "Error: Command failed: %r"%(cmd)
+            self.result = False
 
-        return retval
-
-
-    def __call__(self):
+    def _start(self):
         runfn = "%s/%s.%s.run" % (self.tmpdir, self.name, self.meta.get("DATETIME"))
         runsymlink = "%s/%s.run" % (self.tmpdir, self.name)
 
@@ -208,4 +219,4 @@ class ShellFunction(OEliteFunction):
         if self.meta.get_flag(self.name, "fakeroot"):
             cmd = "%s "%(self.meta.get("FAKEROOT") or "fakeroot") + cmd
         cmd = "LC_ALL=C " + cmd
-        return self.runscript(cmd)
+        return self.startscript(cmd)

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import warnings
 import re
+import subprocess
 
 class OEliteFunction(object):
 
@@ -121,6 +122,28 @@ class ShellFunction(OEliteFunction):
         super(ShellFunction, self).__init__(meta, var, name, tmpdir)
         return
 
+    def runscript(self, cmd):
+        cmdstr = cmd
+        cmdname = cmd.split(None, 1)[0]
+
+        print '> %s'%(cmdstr,)
+
+        try:
+            retval = None
+            returncode = subprocess.call(cmd, stdin=sys.stdin, shell=True)
+            if returncode == 0:
+                retval = True
+            else:
+                print "Error: Command failed: %r: %d"%(cmdstr, returncode)
+        except OSError, e:
+            if e.errno == 2:
+                print "Error: Command not found:", cmdname
+            else:
+                print "Error: Command failed: %r"%(cmdstr)
+
+        return retval
+
+
     def __call__(self):
         runfn = "%s/%s.%s.run" % (self.tmpdir, self.name, self.meta.get("DATETIME"))
         runsymlink = "%s/%s.run" % (self.tmpdir, self.name)
@@ -175,4 +198,4 @@ class ShellFunction(OEliteFunction):
         if self.meta.get_flag(self.name, "fakeroot"):
             cmd = "%s "%(self.meta.get("FAKEROOT") or "fakeroot") + cmd
         cmd = "LC_ALL=C " + cmd
-        return oelite.util.shcmd(cmd)
+        return self.runscript(cmd)

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -1,0 +1,110 @@
+import oebakery
+from oebakery import die, err, warn, info, debug
+from oelite import *
+from recipe import OEliteRecipe
+from runq import OEliteRunQueue
+import oelite.meta
+import oelite.util
+import oelite.arch
+import oelite.parse
+import oelite.task
+import oelite.item
+from oelite.parse import *
+from oelite.cookbook import CookBook
+
+import oelite.fetch
+
+import bb.utils
+
+import sys
+import os
+import glob
+import shutil
+import datetime
+import hashlib
+import logging
+
+class OEliteOven:
+    def __init__(self, baker, capacity):
+        self.capacity = capacity
+        self.baker = baker
+        self.starttime = dict()
+        self.failed_tasks = []
+        self.total = baker.runq.number_of_tasks_to_build()
+        self.count = 0
+
+    def add(self, task):
+        self.capacity -= task.weight
+        self.starttime[task] = datetime.datetime.now()
+
+    def remove(self, task):
+        now = datetime.datetime.now()
+        delta = (now - self.starttime[task]).total_seconds()
+        del self.starttime[task]
+        self.capacity += task.weight
+        return delta
+        
+    def start(self, task):
+        self.add(task)
+
+        self.count += 1
+        debug("")
+        debug("Preparing %s"%(task))
+        task.prepare()
+        info("%s started - %d / %d "%(task, self.count, self.total))
+        task.build_started()
+
+        task.start()
+        
+    def wait_task(self, poll, task):
+        """Wait for a specific task to finish baking. Returns pair (result,
+        delta), or None in case poll=True and the task is not yet
+        done.
+
+        """
+        assert(task in self.starttime)
+        result = task.wait(poll)
+        if result is None:
+            return None
+        delta = self.remove(task)
+
+        if result:
+            info("%s finished - %s s" % (task, delta))
+            task.build_done(self.baker.runq.get_task_buildhash(task))
+            self.baker.runq.mark_done(task)
+        else:
+            err("%s failed - %s s" % (task, delta))
+            self.failed_tasks.append(task)
+            task.build_failed()
+        
+        return (task, result, delta)
+        
+    def wait_any(self, poll):
+        """Wait for any task currently in the oven to finish. Returns triple
+        (task, result, time), or None.
+
+        """
+        if not poll and not self.starttime:
+            raise Exception("nothing in the oven, so you'd wait forever...")
+        tasks = self.starttime.keys()
+        tasks.sort(key=lambda t: self.starttime[t])
+        while True:
+            for t in tasks:
+                result = self.wait_task(True, t)
+                if result is not None:
+                    return result
+            if poll:
+                break
+            time.sleep(0.1)
+        return None
+
+    def wait_all(self, poll):
+        """Do wait_task once for every task currently in the oven once. With
+        poll=False, this amounts to waiting for every current task to
+        finish.
+
+        """
+        tasks = self.starttime.keys()
+        tasks.sort(key=lambda t: self.starttime[t])
+        for t in tasks:
+            self.wait_task(poll, t)

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -34,6 +34,9 @@ class OEliteOven:
         self.total = baker.runq.number_of_tasks_to_build()
         self.count = 0
 
+    def currently_baking(self):
+        return self.starttime.keys()
+
     def add(self, task):
         self.capacity -= task.weight
         self.starttime[task] = datetime.datetime.now()

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -23,6 +23,7 @@ import shutil
 import datetime
 import hashlib
 import logging
+import time
 
 class OEliteOven:
     def __init__(self, baker, capacity):

--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -535,7 +535,7 @@ class OEliteRunQueue:
         return
 
 
-    def get_runabletask(self):
+    def update_runabletasks(self):
         newrunable = self.get_readytasks()
         if newrunable:
             if self.depth_first:
@@ -545,6 +545,9 @@ class OEliteRunQueue:
             for task_id in newrunable:
                 task = self.cookbook.get_task(id=task_id)
                 self.set_task_pending(task)
+
+    def get_runabletask(self):
+        self.update_runabletasks()
         if not self.runable:
             return None
         task_id = self.runable.pop()

--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -555,6 +555,11 @@ class OEliteRunQueue:
             return None
         return self.cookbook.get_task(id=task_id)
 
+    def get_runabletasks(self):
+        self.update_runabletasks()
+        ret = [self.cookbook.get_task(id=task_id) for task_id in self.runable]
+        self.runable = []
+        return ret
 
     def get_metahashable_task(self):
         if not self.metahashable:

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -118,7 +118,7 @@ class OEliteTask:
             os.remove(hashpath)
 
 
-    def prepare(self, runq):
+    def prepare(self):
         meta = self.meta()
 
         buildhash = self.cookbook.baker.runq.get_task_buildhash(self)

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -30,6 +30,7 @@ class OEliteTask:
         self.cookbook = cookbook
         self.debug = self.cookbook.debug
         self._meta = None
+        self.result = None
         return
 
     def __str__(self):
@@ -220,7 +221,7 @@ class OEliteTask:
             os.remove(self.logsymlink)
             os.remove(self.logfn) # prune empty logfiles
 
-    def run(self):
+    def _start(self):
         self.prepare_context()
 
         self.save_context()
@@ -234,23 +235,64 @@ class OEliteTask:
                 if not prefunc.run(wd or self.cwd):
                     return False
             try:
-                if not self.function.run(self.cwd):
-                    return False
+                # start() doesn't return a value - but it may throw an
+                # exception. For, I think, mostly historical reasons,
+                # we catch one specific exception and treat that
+                # essentially as if the last prefunc failed, and let
+                # others trickle up. For now, keep that oddity, since
+                # it doesn't complicate our wait() method.
+                self.function.start(self.cwd)
             except oebakery.FatalError:
                 return False
-            for postfunc in self.get_postfuncs():
-                print "running postfunc", postfunc
-                self.do_cleandirs(postfunc)
-                wd = self.do_dirs(postfunc)
-                if not postfunc.run(wd or self.cwd):
-                    return False
-            return True
-
         finally:
             # Cleanup stdin, stdout and stderr redirection
             self.restore_context()
-            self.cleanup_context()
+        return None
 
+    def start(self):
+        self.result = self._start()
+
+    def wait(self, poll=False):
+        if self.result is not None:
+            # Something bad happened in start
+            self.cleanup_context()
+            return self.result
+
+        self.save_context()
+        self.apply_context()
+
+        try:
+            # Do the actual wait
+            self.result = self.function.wait(poll)
+            assert(self.result in (True, False, None))
+            assert(poll or self.result is not None)
+            # This may have returned None, in case we were just
+            # polling for completion, or False, in case the function
+            # failed. In either case, we shouldn't run the
+            # postfuncs. Otherwise, we should run them.
+            if self.result:
+                for postfunc in self.get_postfuncs():
+                    print "running postfunc", postfunc
+                    self.do_cleandirs(postfunc)
+                    wd = self.do_dirs(postfunc)
+                    if not postfunc.run(wd or self.cwd):
+                        self.result = False
+                        break
+        finally:
+            self.restore_context()
+
+        # If we've gotten an actual True/False answer, it's time to
+        # close the log file and clean up our context. The caller
+        # shouldn't call wait() once the result has been obtained, so
+        # we don't need to make that idempotent.
+        if self.result is not None:
+            self.cleanup_context()
+        return self.result
+
+
+    def run(self):
+        self.start()
+        return self.wait(False)
 
     def do_cleandirs(self, name=None):
         if not name:

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -183,24 +183,17 @@ class OEliteTask:
         self._meta = meta
         return meta
 
-
-    def run(self):
+    def prepare_context(self):
         meta = self.meta()
-        function = meta.get_function(self.name)
-
+        self.function = meta.get_function(self.name)
         self.do_cleandirs()
-        cwd = self.do_dirs() or meta.get("B")
-
-        # Setup stdin, stdout and stderr redirection
-        stdin = open("/dev/null", "r")
-        self.logfn = "%s/%s.%s.log"%(function.tmpdir, self.name, meta.get("DATETIME"))
-        self.logsymlink = "%s/%s.log"%(function.tmpdir, self.name)
+        self.cwd = self.do_dirs() or meta.get("B")
+        self.stdin = open("/dev/null", "r")
+        self.logfn = "%s/%s.%s.log"%(self.function.tmpdir, self.name, meta.get("DATETIME"))
+        self.logsymlink = "%s/%s.log"%(self.function.tmpdir, self.name)
         oelite.util.makedirs(os.path.dirname(self.logfn))
         try:
-            if self.debug:
-                logfile = os.popen("tee %s"%self.logfn, "w")
-            else:
-                logfile = open(self.logfn, "w")
+            self.logfile = open(self.logfn, "w")
         except OSError:
             print "Opening log file failed: %s"%(self.logfn)
             raise
@@ -209,19 +202,46 @@ class OEliteTask:
             os.remove(self.logsymlink)
         os.symlink(os.path.basename(self.logfn), self.logsymlink)
 
-        os.dup2(stdin.fileno(), sys.stdin.fileno())
-        os.dup2(logfile.fileno(), sys.stdout.fileno())
-        os.dup2(logfile.fileno(), sys.stderr.fileno())
+    def save_context(self):
+        self.old_stdin = os.dup(sys.stdin.fileno())
+        self.old_stdout = os.dup(sys.stdout.fileno())
+        self.old_stderr = os.dup(sys.stderr.fileno())
+
+    def apply_context(self):
+        os.dup2(self.stdin.fileno(), sys.stdin.fileno())
+        os.dup2(self.logfile.fileno(), sys.stdout.fileno())
+        os.dup2(self.logfile.fileno(), sys.stderr.fileno())
+
+    def restore_context(self):
+        os.dup2(self.old_stdin, sys.stdin.fileno())
+        os.dup2(self.old_stdout, sys.stdout.fileno())
+        os.dup2(self.old_stderr, sys.stderr.fileno())
+        os.close(self.old_stdin)
+        os.close(self.old_stdout)
+        os.close(self.old_stderr)
+
+    def cleanup_context(self):
+        self.stdin.close()
+        self.logfile.close()
+        if os.path.exists(self.logfn) and os.path.getsize(self.logfn) == 0:
+            os.remove(self.logsymlink)
+            os.remove(self.logfn) # prune empty logfiles
+
+    def run(self):
+        self.prepare_context()
+
+        self.save_context()
+        self.apply_context()
 
         try:
             for prefunc in self.get_prefuncs():
                 print "running prefunc", prefunc
                 self.do_cleandirs(prefunc)
                 wd = self.do_dirs(prefunc)
-                if not prefunc.run(wd or cwd):
+                if not prefunc.run(wd or self.cwd):
                     return False
             try:
-                if not function.run(cwd):
+                if not self.function.run(self.cwd):
                     return False
             except oebakery.FatalError:
                 return False
@@ -229,18 +249,14 @@ class OEliteTask:
                 print "running postfunc", postfunc
                 self.do_cleandirs(postfunc)
                 wd = self.do_dirs(postfunc)
-                if not postfunc.run(wd or cwd):
+                if not postfunc.run(wd or self.cwd):
                     return False
             return True
 
         finally:
             # Cleanup stdin, stdout and stderr redirection
-            self.cookbook.baker.restore_stdio()
-            stdin.close()
-            logfile.close()
-            if os.path.exists(self.logfn) and os.path.getsize(self.logfn) == 0:
-                os.remove(self.logsymlink)
-                os.remove(self.logfn) # prune empty logfiles
+            self.restore_context()
+            self.cleanup_context()
 
 
     def do_cleandirs(self, name=None):

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -203,9 +203,7 @@ class OEliteTask:
         os.symlink(os.path.basename(self.logfn), self.logsymlink)
 
     def save_context(self):
-        self.old_stdin = os.dup(sys.stdin.fileno())
-        self.old_stdout = os.dup(sys.stdout.fileno())
-        self.old_stderr = os.dup(sys.stderr.fileno())
+        self.saved_stdio = oelite.util.StdioSaver()
 
     def apply_context(self):
         os.dup2(self.stdin.fileno(), sys.stdin.fileno())
@@ -213,12 +211,7 @@ class OEliteTask:
         os.dup2(self.logfile.fileno(), sys.stderr.fileno())
 
     def restore_context(self):
-        os.dup2(self.old_stdin, sys.stdin.fileno())
-        os.dup2(self.old_stdout, sys.stdout.fileno())
-        os.dup2(self.old_stderr, sys.stderr.fileno())
-        os.close(self.old_stdin)
-        os.close(self.old_stdout)
-        os.close(self.old_stderr)
+        self.saved_stdio.restore(True)
 
     def cleanup_context(self):
         self.stdin.close()

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -31,11 +31,17 @@ class OEliteTask:
         self.debug = self.cookbook.debug
         self._meta = None
         self.result = None
+        self.weight = self.get_weight()
         return
 
     def __str__(self):
         return "%s:%s"%(self.recipe, self.name)
 
+    def get_weight(self):
+        # Should depend on whether this is do_compile or something
+        # else, and could also be overridden from recipe data. For
+        # now, keep it simple.
+        return 1
 
     def get_parents(self):
         parents = flatten_single_column_rows(self.cookbook.dbc.execute(

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -209,9 +209,6 @@ class OEliteTask:
             os.remove(self.logsymlink)
         os.symlink(os.path.basename(self.logfn), self.logsymlink)
 
-        real_stdin = os.dup(sys.stdin.fileno())
-        real_stdout = os.dup(sys.stdout.fileno())
-        real_stderr = os.dup(sys.stderr.fileno())
         os.dup2(stdin.fileno(), sys.stdin.fileno())
         os.dup2(logfile.fileno(), sys.stdout.fileno())
         os.dup2(logfile.fileno(), sys.stderr.fileno())
@@ -238,14 +235,9 @@ class OEliteTask:
 
         finally:
             # Cleanup stdin, stdout and stderr redirection
-            os.dup2(real_stdin, sys.stdin.fileno())
-            os.dup2(real_stdout, sys.stdout.fileno())
-            os.dup2(real_stderr, sys.stderr.fileno())
+            self.cookbook.baker.restore_stdio()
             stdin.close()
             logfile.close()
-            os.close(real_stdin)
-            os.close(real_stdout)
-            os.close(real_stderr)
             if os.path.exists(self.logfn) and os.path.getsize(self.logfn) == 0:
                 os.remove(self.logsymlink)
                 os.remove(self.logfn) # prune empty logfiles

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -57,6 +57,43 @@ class TeeStream:
             file.write(text)
         return
 
+class StdioSaver:
+    class Fds:
+        def __init__(self):
+            self.stdin = os.dup(sys.stdin.fileno())
+            self.stdout = os.dup(sys.stdout.fileno())
+            self.stderr = os.dup(sys.stderr.fileno())
+            self.refs = 1
+
+        def get(self):
+            self.refs += 1
+            return self
+
+        def put(self):
+            assert(self.refs > 0)
+            self.refs -= 1
+            if self.refs == 0:
+                os.close(self.stdin)
+                os.close(self.stdout)
+                os.close(self.stderr)
+
+    def __init__(self, parent=None):
+        if parent is None:
+            self.fds = self.Fds()
+        else:
+            self.fds = self.parent.fds.get()
+
+    def restore(self, close=True):
+        os.dup2(self.fds.stdin, sys.stdin.fileno())
+        os.dup2(self.fds.stdout, sys.stdout.fileno())
+        os.dup2(self.fds.stderr, sys.stderr.fileno())
+        if close:
+            self.close()
+
+    def close(self):
+        self.fds.put()
+        self.fds = None
+
 
 def shcmd(cmd, dir=None, quiet=False, success_returncode=0,
           silent_errorcodes=[], **kwargs):


### PR DESCRIPTION
This is not ready for merging, but I want to get some comments before spending time on the necessary wider testing, cleanup and "hardening" (testing with various errors injected deliberately).

The last commit shows the potential: when building multiple things, we can get stuff done about 40% faster (wallclock time), and that's before trying to be smart. One of the side effects of this series is what I've wanted for a long time: a breakdown of the time spent on each individual task, and that shows what I've long suspected: do_configure is rather time-consuming, since it usually runs a gazillion compile processes completely serialized.

The overall strategy is quite simple: Instead of having a single task.run() method, split that into a method that starts the task and a method for waiting (or just polling) for its completion, keeping the list of currently running tasks in a suitable data structure. However, the concept of pre- and postfuncs complicates that strategy somewhat, as does the fact that the actual shell script gets called four layers down (baker.py -> task.py -> function.py -> util.shcmd). I took a bottom-up approach, first getting rid of the last layer, since I need to have control over the spawning and waiting for of the subprocess. That also allows me to keep things working as usual by implementing run() as start()+wait() in each of the layers.

