### PR TITLE
gcc: Fix mingw DLL packaging

### DIFF
--- a/recipes/gcc/gcc-common.inc
+++ b/recipes/gcc/gcc-common.inc
@@ -264,6 +264,11 @@ do_install() {
 			mv "$lib" "${D_SYSROOT}${target_libdir}/"
 			ln -s ../../../../${TARGET_ARCH}/sysroot${target_libdir}/`basename $lib` $lib
 		done
+		for lib in "${D_SYSROOT}${target_libdir}"/*.dll ; do
+			[ -e "$lib" ] || continue
+			mkdir -p "${D_SYSROOT}${target_sharedlibdir}"
+			mv "$lib" "${D_SYSROOT}${target_sharedlibdir}/"
+		done
 	fi
 }
 

--- a/recipes/gcc/gcc.inc
+++ b/recipes/gcc/gcc.inc
@@ -70,7 +70,7 @@ AUTO_PACKAGE_LIBS = "gcc gcov atomic gomp itm mudflap mudflapth ssp \
 	stdc++ supc++ quadmath asan tsan ubsan"
 AUTO_PACKAGE_LIBS:canadian-cross = ""
 AUTO_PACKAGE_LIBS_LIBDIR = "/${TARGET_ARCH}/sysroot${target_libdir}:lib:,_s,_s_sjlj,_eh,_nonshared,_pic,_nonshm"
-AUTO_PACKAGE_LIBS_LIBDIR:>TARGET_LIBC_mingw = ":-*.dll"
+AUTO_PACKAGE_LIBS_LIBDIR:>TARGET_LIBC_mingw = ":-*.dll /${TARGET_ARCH}/sysroot${target_sharedlibdir}:lib:,_s,_s_sjlj,_eh,_nonshared,_pic,_nonshm:-*.dll"
 AUTO_PACKAGE_LIBS_DEV_FILES .= ",.map,.spec,_preinit.o"
 AUTO_PACKAGE_LIBS_DEV_FILES:>TARGET_LIBC_mingw = ",.dll.a"
 AUTO_PACKAGE_LIBS_TYPE = "${TARGET_TYPE}"


### PR DESCRIPTION
Move .dll files to sharedlibdir (bin), as they need to be in %PATH%.

Sorry for moving the files around manually, but I did not manage to find
a proper way to convince gcc build system to place them correctly :(

Signed-off-by: Esben Haabendal <esben@haabendal.dk>