### PR TITLE
oeparse.py: remove useless semi-dead code

### DIFF
--- a/lib/oelite/parse/oeparse.py
+++ b/lib/oelite/parse/oeparse.py
@@ -627,12 +627,6 @@ class OEParser(object):
 
         self.filename = os.path.realpath(filename)
 
-        if self.parent:
-            oldfile = os.path.realpath(self.filename[-1])
-            if self.filename == oldfile:
-                print "don't include yourself!"
-                return
-
         if parser is None and not filename.endswith(".oeclass"):
             self.meta.set("FILE", filename)
             self.meta.set("FILE_DIRNAME", os.path.dirname(filename))


### PR DESCRIPTION
Looking through a 38.5M line strace dump, I stumbled on a curious lstat call:

15902 lstat("f", 0x7ffda7538660)        = -1 ENOENT (No such file or directory) <0.000005>

A few syscalls above we've done a getcwd revealing that we're in the
manifest dir. So why on earth do we do this?

The clue came when further down I found an lstat of "s": In the first
case above, we were doing core/conf/fetch/sourceforge.conf, while in
the "s" case we were processing core/classes/c++.oeclass. This
suggests doing

  git grep -E '\[-1'

which quickly points to this chunk of code.

It's a bit sad losing the prank of doing

  ln -s meta/core/conf/fetch/sourceforge.conf f

on a coworker's computer while he's grabbing coffee and see how long
it takes him to figure out what went wrong...

Anyway, if someone feels a check like this should be done, it should
be done properly, and should probably also check the entire ancestry
path and not just the immediate parent for cyclic includes. However, a
quick test shows that Python seems to do this for us implicitly
(although with a not-so-nice error):

RuntimeError: maximum recursion depth exceeded while calling a Python object