### PR TITLE
passwd classes: make them more robust

### DIFF
--- a/classes/image_passwd.oeclass
+++ b/classes/image_passwd.oeclass
@@ -8,22 +8,15 @@ require conf/makedevs.conf
 
 do_rstage[postfuncs] += "do_rstage_passwd_concat"
 do_rstage_passwd_concat () {
-	cwd=`pwd`
-	if [ -d $cwd/${passwddir} ]; then
-		for f in $cwd/${passwddir}/* ; do
-			cat $f >> $cwd/${passwdfile}
-			rm $f
-		done
-		sort -g -t : -k 3 -o $cwd/${passwdfile} $cwd/${passwdfile}
-		rm -rf $cwd/${passwddir}
+	if [ -d ./${passwddir} ]; then
+		cat /dev/null $(find ./${passwddir} -type f) >> ./${passwdfile}
+		sort -g -t : -k 3 -o ./${passwdfile} ./${passwdfile}
+		rm -rf ./${passwddir}
 	fi
-	if [ -d $cwd/${groupdir} ]; then
-		for f in $cwd/${groupdir}/* ; do
-			cat $f >> $cwd/${groupfile}
-			rm $f
-		done
-		sort -g -t : -k 3 -o $cwd/${groupfile} $cwd/${groupfile}
-		rm -rf $cwd/${groupdir}
+	if [ -d ./${groupdir} ]; then
+		cat /dev/null $(find ./${groupdir} -type f) >> ./${groupfile}
+		sort -g -t : -k 3 -o ./${groupfile} ./${groupfile}
+		rm -rf ./${groupdir}
 	fi
 }
 

--- a/classes/image_passwd.oeclass
+++ b/classes/image_passwd.oeclass
@@ -160,6 +160,27 @@ def do_rstage_passwd_groups(d):
             group_line += "\n"
             group_file.write(group_line)
 
+do_rstage[postfuncs] += "do_rstage_passwd_check_unique_uidgid"
+do_rstage_passwd_check_unique_uidgid () {
+	local dupuids=$(cut -f3 -d: ${passwdfile} | uniq -d)
+	if [ -n "$dupuids" ] ; then
+		echo -n "ERROR: duplicate uids:   "
+		echo $dupuids
+		echo "Conflicting entries:"
+		grep -w -F "$dupuids" ${passwdfile}
+		exit 1
+	fi
+
+	local dupgids=$(cut -f3 -d: ${groupfile} | uniq -d)
+	if [ -n "$dupgids" ] ; then
+		echo -n "ERROR: duplicate gids:   "
+		echo $dupgids
+		echo "Conflicting entries:"
+		grep -w -F "$dupgids" ${groupfile}
+		exit 1
+	fi
+}
+
 # Local Variables:
 # mode: python
 # End:

--- a/classes/passwd.oeclass
+++ b/classes/passwd.oeclass
@@ -1,11 +1,20 @@
 ## OE-lite class for recipes providing content for /etc/passwd and /etc/group
 ##
-## If a recipe has contents for /etc/passwd or /etc/group, just ensure that the
-## content for /etc/passwd is placed in PASSWD_FILES, and contents for
-## /etc/group in GROUP_FILES. The contents from a recipe is placed in
-## a recipe specific dir, so that multiple recipes may provides contents for
-## /etc/passwd and /etc/group. The content is later combined in the
-## image_passwd class.
+## If a recipe has contents for /etc/passwd or /etc/group, just ensure
+## that the content for /etc/passwd is placed in PASSWD_FILES, and
+## contents for /etc/group in GROUP_FILES. The contents from a recipe
+## is placed in a recipe specific dir, so that multiple recipes may
+## provides contents for /etc/passwd and /etc/group. The content is
+## later combined in the image_passwd class.
+##
+## Currently, all files from a given recipe must have different
+## basenames; the file $f gets copied to
+##
+##   ${passwddir}/${PN}/$(basename $f)
+##
+## Should this ever become a problem that cannot be solved by
+## appropriate renaming, see https://github.com/oe-lite/core/pull/154
+## for a possible extension.
 ##
 ## @var PASSWD_FILES Set the ${SRCDIR}/passwd by default.
 ## @var GROUP_FILES Set to ${SRCDIR}/group by default.
@@ -19,18 +28,14 @@ GROUP_FILES ?= "${SRCDIR}/group"
 PASSWD_POSTFUNC:machine = " do_install_passwd"
 do_install[postfuncs] += "${PASSWD_POSTFUNC}"
 do_install_passwd () {
-	i=0
 	for f in ${PASSWD_FILES} ; do
-		mkdir -p ${D}/${passwddir}
-		let i=$i+1
-		cp $f ${D}/${passwddir}/${PN}.$i
+		mkdir -p ${D}/${passwddir}/${PN}
+		cp -n $f ${D}/${passwddir}/${PN}/
 	done
 
-	i=0
 	for f in ${GROUP_FILES} ; do
-		mkdir -p ${D}/${groupdir}
-		let i=$i+1
-		cp $f ${D}/${groupdir}/${PN}.$i
+		mkdir -p ${D}/${groupdir}/${PN}
+		cp -n $f ${D}/${groupdir}/${PN}/
 	done
 }
 do_install_passwd[expand] = "3"


### PR DESCRIPTION
There's a bug in the current avahi recipe: The autoipd-passwd and
daemon-passwd files end up being packaged under the names avahi.1 and
avahi.2, but in the packages' respective FILES_* list they list each
others' files. This means that when one includes one but not the other
package, the expected user account is missing from the system.

Having to manually enumerate the PASSWD_FILES the same way the passwd
class does it is rather fragile. So instead of renaming the files to
${PN}.${i}, put each recipe's passwd files in the subdirectory ${PN} and
keep the file's basename. That makes the relevant FILES entries much
more predictable.

While at it, replace $cwd with . in image_passed.oeclass - avoiding
long absolute paths makes it easier to read the log output.