### PR TITLE
lib/oelite: Also prune git remotes on fetch

### DIFF
--- a/lib/oelite/git.py
+++ b/lib/oelite/git.py
@@ -126,7 +126,7 @@ class GitRepository(object):
             if url != oldurl:
                 self.set_url(url)
         try:
-            return self.git("remote update", quiet=False) is True
+            return self.git("remote update --prune", quiet=False) is True
         finally:
             if url and url != oldurl:
                 self.set_url(oldurl)


### PR DESCRIPTION
This is similar to PR #143, but where #143 fixed it for mirror task,
this does the same for fetch task.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>