### PR TITLE
class/kernel: Don't overwrite EXTRA_OEMAKE

### DIFF
--- a/classes/kernel-common.oeclass
+++ b/classes/kernel-common.oeclass
@@ -11,7 +11,7 @@ KERNEL_VERSION_PATCHLEVEL = "${@'.'.join(d.get('PV').split('.')[:2])}"
 
 # For the kernel, we don't want the '-e MAKEFLAGS=' in EXTRA_OEMAKE.
 # We don't want to override kernel Makefile variables from the environment
-EXTRA_OEMAKE = "ARCH=${KERNEL_ARCH}"
+EXTRA_OEMAKE += "ARCH=${KERNEL_ARCH}"
 
 CFLAGS[unexport]   = "1"
 CPPFLAGS[unexport] = "1"


### PR DESCRIPTION
It does not make sense that EXTRA_OEMAKE is overwritten if recipe sets
EXTRA_OEMAKE prior to inheriting kernel class.

This change is technically not backwards compatible though!

Signed-off-by: Esben Haabendal <esben@haabendal.dk>