### PR TITLE
oelite/fetch/svn.py: import pysvn lazily

### DIFF
--- a/lib/oelite/fetch/svn.py
+++ b/lib/oelite/fetch/svn.py
@@ -6,7 +6,6 @@ import time
 import warnings
 import hashlib
 import oelite.fetch
-import pysvn
 import tarfile
 from oelite.fetch.url import grab
 
@@ -43,6 +42,15 @@ from oelite.fetch.url import grab
 # from ingredients to a skeleton source directory tree, and svn update is then
 # called to checkout the required revision.
 #
+
+# pysvn pulls in _a lot_ of shared libraries.  Since our
+# primary cost of fork'ing is the COW'ing of our entire
+# address space, and since nobody actually uses the svn
+# fetcher, we use this little trick for importing the pysvn
+# module lazily rather than doing it at the top of the file.
+def _lazy_import():
+    global pysvn
+    import pysvn
 
 class SvnFetcher():
 
@@ -111,6 +119,7 @@ class SvnFetcher():
         return bool(self._signature)
 
     def get_revision(self):
+        _lazy_import()
         try:
             return self._rev
         except:
@@ -136,6 +145,7 @@ class SvnFetcher():
         return self._rev
 
     def update_ingredients_wc(self):
+        _lazy_import()
         print "Updating ingredients working copy"
         client = pysvn.Client()
         if os.path.exists(self.wc):
@@ -288,6 +298,7 @@ class SvnFetcher():
         return
 
     def unpack(self, d):
+        _lazy_import()
         # Note: when self.localpath is set, this method is not called, but
         # unpacking is instead handled by OEliteUri.unpack method directly.
         client = pysvn.Client()


### PR DESCRIPTION
Our memory footprint is still humongous, but for now I'm out of ideas
for reducing the size of python objects. Looking at /proc/self/maps,
however, reveals that pysvn is responsible for pulling in lots of
shared libraries. Since there isn't a single recipe currently relying
on the svn fetcher, I think this little piece of complexity is worth
it.

Comparing the maps file before and after shows that we save around 93
VMAs covering 74 MiB of address space. That's a lot of pages to avoid
COW'ing for every fork() we do.

I originally did the lazy import in the __init__ method, but then we
don't save anything if there is a recipe with an svn url, even if
we're not actually building that recipe (the import would happen
during recipe parsing).

I've tested this by reinstating the eglibc recipe as it was just
before db8b520b (glibc: Upgrade from eglibc 2.18 to glibc 2.21),
fixing the SRC_URI line back to how it was before b65d98f7 (eglibc:
use svn protocol instead of http (issue with web server)), and then
running "oe bake eglibc -t unpack" with and without this patch -
obviously cleaning ingredients, stamps etc. between runs.