### PR TITLE
oelite/fetch/url.py: lazily import urlgrabber

### DIFF
--- a/lib/oelite/fetch/url.py
+++ b/lib/oelite/fetch/url.py
@@ -1,8 +1,6 @@
 import oelite.fetch
 import oelite.util
 import os
-import urlgrabber
-import urlgrabber.progress
 import hashlib
 from oebakery import die, err, warn, info, debug
 
@@ -115,12 +113,15 @@ class UrlFetcher():
         return False
 
 
-class SimpleProgress(urlgrabber.progress.BaseMeter):
-    def _do_end(self, amount_read, now=None):
-        print "grabbed %d bytes in %.2f seconds" %(amount_read,self.re.elapsed_time())
 
 
 def grab(url, filename, timeout=120, retry=5, proxy=None, ftpmode=False):
+    import urlgrabber
+    import urlgrabber.progress
+    class SimpleProgress(urlgrabber.progress.BaseMeter):
+        def _do_end(self, amount_read, now=None):
+            print "grabbed %d bytes in %.2f seconds" %(amount_read,self.re.elapsed_time())
+
     print "Grabbing", url
     def grab_fail_callback(data):
         # Only print debug here when non fatal retries, debug in other cases


### PR DESCRIPTION
It turns out that the urlgrabber module is responsible for pulling in
about half the shared objects we use. If we have all ingredients
downloaded already, there's no reason for polluting our VM with all
that.

Fortunately, we only use urlgrabber in a single function, so this is a
rather small patch.

We end up having 149 fewer entries in /proc/self/maps (178 vs 327),
accounting for 147 MiB of address space.

To see how much a large VM affects fork() cost one can play with this
little script:

#!/usr/bin/python

import os
import sys
# Enabling this...
#import pysvn

count = 0
size = 0
with open("/proc/self/maps") as f:
    for l in f:
        print l,
        r, rest = l.strip().split(" ", 1)
        begin,end = r.split("-")
        count += 1
        size += int(end, 16) - int(begin, 16)

print "%d VMAs, total size %d KiB" % (count, size/1024)
sys.stdout.flush()

# or this makes fork() take much longer.
#y = range(100000)

for i in xrange(10000):
    pid = os.fork()
    if pid == 0:
        sys.exit(0)
    os.waitpid(pid, 0)

For me, adding the pysvn import alone bumps the execution time from
19.5 to 26.5 seconds.