### PR TITLE
Parallel task preparation

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -581,7 +581,6 @@ class OEliteBaker:
             debug("")
             debug("Preparing %s"%(task))
             task.prepare()
-            meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()
             if self.options.fake_build or task.run():

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -294,7 +294,7 @@ class OEliteBaker:
         # first, add complete dependency tree, with complete
         # task-to-task and task-to-package/task dependency information
         debug("Building dependency tree")
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         for task in self.tasks_todo:
             task = oelite.task.task_name(task)
             try:
@@ -360,7 +360,7 @@ class OEliteBaker:
         task = self.runq.get_metahashable_task()
         total = self.runq.number_of_runq_tasks()
         count = 0
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         while task:
             oelite.util.progress_info("Calculating task metadata hashes",
                                       total, count)
@@ -571,7 +571,7 @@ class OEliteBaker:
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
         task = self.runq.get_runabletask()
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         total = self.runq.number_of_tasks_to_build()
         count = 0
         exitcode = 0

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -259,6 +259,7 @@ class OEliteBaker:
     def bake(self):
 
         self.setup_tmpdir()
+        oelite.profiling.init(self.config)
 
         # task(s) to do
         if self.options.task:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -294,7 +294,7 @@ class OEliteBaker:
         # first, add complete dependency tree, with complete
         # task-to-task and task-to-package/task dependency information
         debug("Building dependency tree")
-        start = oelite.util.now()
+        rusage = oelite.profiling.Rusage("Building dependency tree")
         for task in self.tasks_todo:
             task = oelite.task.task_name(task)
             try:
@@ -312,7 +312,7 @@ class OEliteBaker:
                 die("No such task: %s: %s"%(thing, e.__str__()))
             except oebakery.FatalError, e:
                 die("Failed to add %s:%s to runqueue"%(thing, task))
-        oelite.util.timing_info("Building dependency tree", start)
+        rusage.end()
 
         # Generate recipe dependency graph
         recipes = set([])
@@ -360,7 +360,7 @@ class OEliteBaker:
         task = self.runq.get_metahashable_task()
         total = self.runq.number_of_runq_tasks()
         count = 0
-        start = oelite.util.now()
+        rusage = oelite.profiling.Rusage("Calculating task metadata hashes")
         while task:
             oelite.util.progress_info("Calculating task metadata hashes",
                                       total, count)
@@ -434,7 +434,7 @@ class OEliteBaker:
         oelite.util.progress_info("Calculating task metadata hashes",
                                   total, count)
 
-        oelite.util.timing_info("Calculation task metadata hashes", start)
+        rusage.end()
 
         if count != total:
             print ""
@@ -571,7 +571,7 @@ class OEliteBaker:
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
         task = self.runq.get_runabletask()
-        start = oelite.util.now()
+        rusage = oelite.profiling.Rusage("Build")
         total = self.runq.number_of_tasks_to_build()
         count = 0
         exitcode = 0
@@ -595,7 +595,7 @@ class OEliteBaker:
                 # FIXME: support command-line option to abort on first
                 # failed task
             task = self.runq.get_runabletask()
-        oelite.util.timing_info("Build", start)
+        rusage.end()
 
         if exitcode:
              for task in failed_task_list:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -580,7 +580,7 @@ class OEliteBaker:
             count += 1
             debug("")
             debug("Preparing %s"%(task))
-            task.prepare(self.runq)
+            task.prepare()
             meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -11,6 +11,7 @@ import oelite.task
 import oelite.item
 from oelite.parse import *
 from oelite.cookbook import CookBook
+import oelite.profiling
 
 import oelite.fetch
 
@@ -89,6 +90,7 @@ def add_show_parser_options(parser):
 
 class OEliteBaker:
 
+    @oelite.profiling.profile_rusage_delta
     def __init__(self, options, args, config):
         self.options = options
         self.debug = self.options.debug

--- a/lib/oelite/compat.py
+++ b/lib/oelite/compat.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+import os
+import fcntl
+import ctypes
+import datetime
+import sys
+
+__all__ = ["dup_cloexec", "open_cloexec"]
+
+uname = os.uname()
+sysname, release, machine = (uname[0], uname[2], uname[4])
+
+values = dict()
+if (sysname, machine) == ("Linux", "x86_64"):
+    # these are supported since at least 2.6.24, so just set them unconditionally
+    values['O_CLOEXEC'] = 02000000
+    values['F_DUPFD_CLOEXEC'] = 1024+6
+
+# import bb.utils doesn't work when we try to run this by itself (to
+# test it), so this just serves to show what one could do, provided
+# someone figures out how to make the vercmp_string available.
+#
+# elif sysname == "FreeBSD":
+#     if bb.utils.vercmp_string(release, "8.3") >= 0:
+#         values['O_CLOEXEC'] = 0x00100000
+#     if bb.utils.vercmp_string(release, "9.2") >= 0:
+#         values['F_DUPFD_CLOEXEC'] = 17
+
+def dup_cloexec(fd):
+    return fcntl.fcntl(fd, F_DUPFD_CLOEXEC, 0)
+
+def open_cloexec(filename, flag, mode=0777):
+    return os.open(filename, flag | O_CLOEXEC, mode)
+
+def set_cloexec(fd):
+    fcntl.fcntl(fd, fcntl.F_SETFD, fcntl.FD_CLOEXEC)
+    return fd
+
+def dup_cloexec_fallback(fd):
+    return set_cloexec(os.dup(fd))
+
+def open_cloexec_fallback(filename, flag, mode=0777):
+    return set_cloexec(os.open(filename, flag, mode))
+
+if hasattr(os, "O_CLOEXEC"):
+    O_CLOEXEC = os.O_CLOEXEC
+else:
+    try:
+        O_CLOEXEC = values["O_CLOEXEC"]
+    except KeyError:
+        open_cloexec = open_cloexec_fallback
+
+if hasattr(fcntl, "F_DUPFD_CLOEXEC"):
+    F_DUPFD_CLOEXEC = fcntl.F_DUPFD_CLOEXEC
+else:
+    try:
+        F_DUPFD_CLOEXEC = values["F_DUPFD_CLOEXEC"]
+    except KeyError:
+        dup_cloexec = dup_cloexec_fallback
+
+
+def has_cloexec(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+    return (flags & fcntl.FD_CLOEXEC) != 0
+
+def test_open_cloexec():
+    fd = open_cloexec("/dev/null", os.O_RDONLY)
+    assert(has_cloexec(fd))
+    os.close(fd)
+    fd = open_cloexec("/dev/null", os.O_WRONLY)
+    assert(has_cloexec(fd))
+    os.close(fd)
+
+def test_dup_cloexec():
+    fd = dup_cloexec(sys.stdin.fileno())
+    assert(has_cloexec(fd))
+    os.close(fd)
+
+
+if __name__ == "__main__":
+    test_open_cloexec()
+    test_dup_cloexec()

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -10,6 +10,7 @@ import oelite.meta
 import oelite.package
 import oelite.path
 import bb.utils
+import oelite.profiling
 
 import sys
 import os
@@ -23,7 +24,7 @@ from collections import Mapping
 
 class CookBook(Mapping):
 
-
+    @oelite.profiling.profile_rusage_delta
     def __init__(self, baker):
         self.baker = baker
         self.config = baker.config
@@ -44,6 +45,7 @@ class CookBook(Mapping):
         recipefiles = self.list_recipefiles()
         total = len(recipefiles)
         count = 0
+        rusage = oelite.profiling.Rusage("recipe parsing")
         for recipefile in recipefiles:
             count += 1
             if self.debug:
@@ -73,6 +75,7 @@ class CookBook(Mapping):
                 err("Uncaught Python exception in %s"%(
                         self.shortfilename(recipefile)))
                 fail = True
+        rusage.end()
         if fail:
             die("Errors while adding recipes to cookbook")
 

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -23,7 +23,6 @@ class OEliteFunction(object):
             self.tmpdir = self.meta.get("T")
             if not self.tmpdir:
                 die("T variable not set, unable to build")
-        self.flags = meta.get_flags(var, oelite.meta.FULL_EXPANSION)
         return
 
     def __str__(self):

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -98,8 +98,10 @@ class Rusage:
 
     def start(self):
         self.before = self.current_rusage()
+        oelite.util.stracehack("start:" + self.name)
 
     def end(self):
+        oelite.util.stracehack("end:" + self.name)
         self.after = self.current_rusage()
 
         if profiledir:

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -5,6 +5,7 @@ import oelite.util
 import inspect
 import os
 import sys
+import subprocess
 from resource import *
 
 now = datetime.datetime.utcnow
@@ -144,6 +145,14 @@ def write_basic_info(config):
     with profile_output("info.txt") as f:
         f.write("argv: %s\n" % " ".join(sys.argv))
         f.write("PARALLEL_MAKE: %s\n" % (config.get("PARALLEL_MAKE") or ""))
+        for layer in (config.get("OESTACK") or "").split():
+            layer = layer.split(";")[0]
+            cmd = "cd %s && git describe --long --dirty --abbrev=10 --tags --always" % layer
+            try:
+                desc = subprocess.check_output(cmd, shell=True)
+            except subprocess.CalledProcessError:
+                desc = "unknown\n"
+            f.write("%s: %s" % (layer, desc))
 
 def init(config):
     global profiledir

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -1,0 +1,188 @@
+import datetime
+import functools
+import atexit
+import oelite.util
+import inspect
+import os
+import sys
+from resource import *
+
+now = datetime.datetime.utcnow
+
+profiledir = None
+
+# Decorating any function with @profile_calls will record the duration
+# of every call of that function. Some statistics on these are
+# automatically printed to $profiledir/callstats.txt on exit.
+profiled_functions = dict()
+def profile_calls(somefunc):
+    @functools.wraps(somefunc)
+    def recordtime(*args, **kwargs):
+        start = now()
+        try:
+            return somefunc(*args, **kwargs)
+        finally:
+            delta = (now()-start).total_seconds()
+            if not somefunc in profiled_functions:
+                profiled_functions[somefunc] = SimpleStats()
+            profiled_functions[somefunc].append(delta)
+    return recordtime
+
+def write_call_stats():
+    outfn = os.path.join(profiledir, "call_stats.txt")
+    with open(outfn, "w") as out:
+        for f in sorted(profiled_functions.keys(), key=lambda x: x.__name__):
+            name = f.__name__
+            try:
+                srcfile = os.path.basename(inspect.getsourcefile(f))
+            except TypeError:
+                srcfile = "<unknown>"
+
+            stats = profiled_functions[f]
+            stats.compute()
+            out.write("%-12s\t%-24s\t%9.3fs / %5d = %7.3f " %
+                    (srcfile, f.__name__,
+                     stats.sum, stats.count, stats.mean))
+            out.write("[%s]\n" % ", ".join(["%7.3f" % x for x in stats.quartiles]))
+
+# For detailed profiling of individual phases (recipe parsing, hash
+# computation, entire build, ...) - records memory information as well
+# as wallclock, user and system times.
+class Rusage:
+    rusage_names = [
+        ("wtime",     "wallclock time", "%7.3f"),
+        ("ru_stime",  "system time   ", "%7.3f"),
+        ("ru_utime",  "user time     ", "%7.3f"),
+        ("ru_minflt", "minor faults  ", "%7d"),
+        ("ru_majflt", "major faults  ", "%7d"),
+        ("ru_maxrss", "max RSS       ", "%7d KiB"),
+        ("ru_nvcsw",  "context switches, voluntary  ", "%7d"),
+        ("ru_nivcsw", "context switches, involuntary", "%7d"),
+    ]
+    # For recording deltas before profiledir is created
+    deferred = []
+
+    def compute_delta(self):
+        delta = dict()
+        for m,_,_ in Rusage.rusage_names:
+            delta[m] = self.after[m] - self.before[m]
+        delta['wtime'] = delta['wtime'].total_seconds()
+        self.delta = delta
+
+    @classmethod
+    def current_rusage(self):
+        # Reading /proc/self/status, in particular the VmPeak and
+        # VmSize fields, may also be interesting.
+        x = getrusage(RUSAGE_SELF)
+        y = dict([(m, getattr(x, m)) for m,_,_ in self.rusage_names if m.startswith("ru_")])
+        y["wtime"] = now()
+        return y
+
+    def print_delta(self):
+        self.compute_delta()
+        outfn = os.path.join(profiledir, "rusage_delta.txt")
+        with open(outfn, "a") as f:
+            f.write("%s:\n" % self.name)
+            for key, name, fmt in self.rusage_names:
+                f.write(("  %s " + fmt + "\n") % (name, self.delta[key]))
+            f.write("\n")
+
+    @classmethod
+    def print_deferred(self):
+        for p in self.deferred:
+            p.print_delta()
+
+    def __init__(self, name):
+        self.name = name
+        self.start()
+
+    def start(self):
+        self.before = self.current_rusage()
+
+    def end(self):
+        self.after = self.current_rusage()
+
+        if profiledir:
+            self.print_delta()
+        else:
+            Rusage.deferred.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.end()
+
+# For easy automatic 10000 foot profiling of run-once (or run rarely)
+# functions, just decorate it with
+#
+# @oelite.profiling.profile_rusage_delta
+def profile_rusage_delta(somefunc):
+    @functools.wraps(somefunc)
+    def recorddelta(*args, **kwargs):
+        name = somefunc.__name__
+        try:
+            srcfile = os.path.basename(inspect.getsourcefile(somefunc))
+        except TypeError:
+            srcfile = "<unknown>"
+        try:
+            lineno = str(inspect.getsourcelines(somefunc)[1])
+        except:
+            lineno = "?"
+        with Rusage("%s:%s:%s" % (srcfile, lineno, name)):
+            return somefunc(*args, **kwargs)
+    return recorddelta
+
+def write_basic_info(config):
+    outfn = os.path.join(profiledir, "info.txt")
+    with open(outfn, "w") as f:
+        f.write("argv: %s\n" % " ".join(sys.argv))
+        f.write("PARALLEL_MAKE: %s\n" % (config.get("PARALLEL_MAKE") or ""))
+
+def init(config):
+    global profiledir
+    profiledir = os.path.join(config.get("TMPDIR"), "profiling", config.get("DATETIME"))
+    oelite.util.makedirs(profiledir)
+    linkpath = os.path.join(config.get("TMPDIR"), "profiling", "latest")
+    try:
+        os.unlink(linkpath)
+    except OSError:
+        pass
+    os.symlink(config.get("DATETIME"), linkpath)
+
+    write_basic_info(config)
+    Rusage.print_deferred()
+
+    atexit.register(write_call_stats)
+
+class SimpleStats:
+    def __init__(self):
+        self.data = []
+
+    def append(self, val):
+        self.data.append(val)
+
+    def compute(self):
+        self.data.sort()
+        self.sum = sum(self.data)
+        self.count = len(self.data)
+        try:
+            self.mean = self.sum / len(self.data)
+        except ZeroDivisionError:
+            self.mean = float('nan')
+        self.quartiles = [self.percentile(p) for p in (0,25,50,75,100)]
+
+    def percentile(self, p):
+        if len(self.data) == 0:
+            return float('nan')
+        elif len(self.data) == 1:
+            return self.data[0]
+        p = float(p)
+        if p < 0.0 or p > 100.0:
+            raise ValueError("p outside valid range")
+        p /= 100.0
+        p *= len(self.data)-1
+        i = int(p)
+        if i == len(self.data)-1:
+            return self.data[-1]
+        return (p-i)*(self.data[i+1]-self.data[i]) + self.data[i]

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -11,6 +11,13 @@ now = datetime.datetime.utcnow
 
 profiledir = None
 
+def profile_output(name, mode="a"):
+    if profiledir:
+        path = os.path.join(profiledir, name)
+    else:
+        path = "/dev/null"
+    return open(path, mode)
+
 # Decorating any function with @profile_calls will record the duration
 # of every call of that function. Some statistics on these are
 # automatically printed to $profiledir/callstats.txt on exit.
@@ -29,8 +36,7 @@ def profile_calls(somefunc):
     return recordtime
 
 def write_call_stats():
-    outfn = os.path.join(profiledir, "call_stats.txt")
-    with open(outfn, "w") as out:
+    with profile_output("call_stats.txt") as out:
         for f in sorted(profiled_functions.keys(), key=lambda x: x.__name__):
             name = f.__name__
             try:
@@ -80,8 +86,7 @@ class Rusage:
 
     def print_delta(self):
         self.compute_delta()
-        outfn = os.path.join(profiledir, "rusage_delta.txt")
-        with open(outfn, "a") as f:
+        with profile_output("rusage_delta.txt") as f:
             f.write("%s:\n" % self.name)
             for key, name, fmt in self.rusage_names:
                 f.write(("  %s " + fmt + "\n") % (name, self.delta[key]))
@@ -136,8 +141,7 @@ def profile_rusage_delta(somefunc):
     return recorddelta
 
 def write_basic_info(config):
-    outfn = os.path.join(profiledir, "info.txt")
-    with open(outfn, "w") as f:
+    with profile_output("info.txt") as f:
         f.write("argv: %s\n" % " ".join(sys.argv))
         f.write("PARALLEL_MAKE: %s\n" % (config.get("PARALLEL_MAKE") or ""))
 

--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -947,7 +947,7 @@ class OEliteRunQueue:
 
     def prune_runq_depends_nobuild(self):
         rowcount = 0
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         while True:
             self.dbc.execute(
                 "UPDATE runq.depend SET parent_task=NULL "
@@ -969,7 +969,7 @@ class OEliteRunQueue:
     def prune_runq_depends_with_nobody_depending_on_it(self):
         #c = self.dbc.cursor()
         rowcount = 0
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         while True:
             # The code below, until the executemany() call, implements
             # what was previously done with this horribly-performing
@@ -1001,7 +1001,7 @@ class OEliteRunQueue:
 
 
     def prune_runq_tasks(self):
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         rowcount = self.dbc.execute(
             "UPDATE"
             "  runq.task "

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -117,7 +117,7 @@ class OEliteTask:
             os.remove(hashpath)
 
 
-    def prepare(self, runq):
+    def prepare(self):
         meta = self.meta()
 
         buildhash = self.cookbook.baker.runq.get_task_buildhash(self)

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -57,6 +57,11 @@ class TeeStream:
             file.write(text)
         return
 
+def stracehack(msg):
+    try:
+        os.write(-42, msg)
+    except OSError:
+        pass
 
 def shcmd(cmd, dir=None, quiet=False, success_returncode=0,
           silent_errorcodes=[], **kwargs):

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -171,18 +171,23 @@ def touch(path, makedirs=False, truncate=False):
         os.utime(path, None)
 
 
+def pretty_time(delta):
+    milliseconds = int(1000*(delta % 1))
+    delta = int(delta)
+    seconds = delta % 60
+    minutes = delta // 60 % 60
+    hours = delta // 3600
+    if hours:
+        return "%dh%02dm%02ds"%(hours, minutes, seconds)
+    elif minutes:
+        return "%dm%02ds"%(minutes, seconds)
+    else:
+        return "%d.%03d seconds"%(seconds, milliseconds)
+
+
 def timing_info(msg, start):
     msg += " time "
-    delta = datetime.datetime.now() - start
-    hours = delta.seconds // 3600
-    minutes = delta.seconds // 60 % 60
-    seconds = delta.seconds % 60
-    milliseconds = delta.microseconds // 1000
-    if hours:
-        msg += "%dh%02dm%02ds"%(hours, minutes, seconds)
-    elif minutes:
-        msg += "%dm%02ds"%(minutes, seconds)
-    else:
-        msg += "%d.%03d seconds"%(seconds, milliseconds)
+    delta = (datetime.datetime.now() - start).total_seconds()
+    msg += pretty_time(delta)
     info(msg)
     return

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -6,6 +6,8 @@ import subprocess
 import datetime
 
 
+now = datetime.datetime.utcnow
+
 def format_textblock(text, indent=2, width=78, first_indent=None):
     """
     Format a text block.
@@ -187,7 +189,7 @@ def pretty_time(delta):
 
 def timing_info(msg, start):
     msg += " time "
-    delta = (datetime.datetime.now() - start).total_seconds()
+    delta = (now() - start).total_seconds()
     msg += pretty_time(delta)
     info(msg)
     return


### PR DESCRIPTION
These patches should be completely innocent. Some remove dead code (which is nice to get rid of, because that makes it easier to reason about the patches that implement the parallel task feature). Some just do some trivial refactoring. Some prepare for performance/correctness improvements which are not directly parallel task-relevant. And some add profiling infrastructure, since I was getting tired of having to bolt that on and off when trying to measure things. The profiling which is done by default obviously has to be extremely low overhead, but having the rest of the infrastructure available means I only have to add a single line or two instead of the entire implementation.

From here, it's only about 15 more patches to parallel tasks :)