### PR TITLE
linux-headers: version bump to 4.4.23

### DIFF
--- a/recipes/linux-headers/linux-headers_4.4.23.oe
+++ b/recipes/linux-headers/linux-headers_4.4.23.oe
@@ -1,0 +1,2 @@
+require ${PN}.inc
+require linux-stable.inc

--- a/recipes/linux-headers/linux-headers_4.4.23.oe.sig
+++ b/recipes/linux-headers/linux-headers_4.4.23.oe.sig
@@ -1,0 +1,1 @@
+d19e48fe5da7b83d02ed4aec3567f08ae02a168c  git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;tag=v4.4.23


### PR DESCRIPTION
Bump linux-headers to newest LTS
