### PR TITLE
setup/ubuntu*: generate en_US.UTF-8 locale

### DIFF
--- a/setup/ubuntu_12.04
+++ b/setup/ubuntu_12.04
@@ -1,2 +1,3 @@
 # Ubuntu 12.04
 sudo apt-get --yes install python-support python-magic python-pycurl python-pkg-resources python-dev coreutils sed git-core cvs subversion quilt gawk texinfo automake autoconf autopoint libtool curl texi2html diffstat openjade groff mtd-utils build-essential make gcc g++ binutils bison flex bc ncurses-dev zip unzip lzma gtk-doc-tools docbook-utils libxml2-utils xmlto help2man libglib2.0-dev lzop gperf python-svn libacl1-dev
+sudo locale-gen en_US.UTF-8 en_US

--- a/setup/ubuntu_13.04
+++ b/setup/ubuntu_13.04
@@ -1,2 +1,3 @@
 # Ubuntu 13.04
 sudo apt-get --yes install python-support python-magic python-pycurl python-pkg-resources python-dev coreutils sed git-core cvs subversion quilt gawk texinfo automake autoconf autopoint libtool curl texi2html diffstat openjade groff mtd-utils build-essential make gcc g++ binutils bison flex bc ncurses-dev zip unzip lzma gtk-doc-tools docbook-utils libxml2-utils xmlto help2man libglib2.0-dev lzop gperf python-svn libacl1-dev
+sudo locale-gen en_US.UTF-8 en_US

--- a/setup/ubuntu_13.10
+++ b/setup/ubuntu_13.10
@@ -1,2 +1,3 @@
 # Ubuntu 13.10
 sudo apt-get --yes install python-support python-magic python-pycurl python-pkg-resources python-dev coreutils sed git-core cvs subversion quilt gawk texinfo automake autoconf autopoint libtool curl texi2html diffstat openjade groff mtd-utils build-essential make gcc g++ binutils bison flex bc ncurses-dev zip unzip lzma gtk-doc-tools docbook-utils libxml2-utils xmlto help2man libglib2.0-dev lzop gperf python-svn libacl1-dev
+sudo locale-gen en_US.UTF-8 en_US

--- a/setup/ubuntu_14.04
+++ b/setup/ubuntu_14.04
@@ -1,2 +1,3 @@
 # Ubuntu 14.04
 sudo apt-get --yes install python-support python-magic python-pycurl python-pkg-resources python-dev coreutils sed git-core cvs subversion quilt gawk texinfo automake autoconf autopoint libtool curl texi2html diffstat openjade groff mtd-utils build-essential make gcc g++ binutils bison flex bc ncurses-dev zip unzip lzma gtk-doc-tools docbook-utils libxml2-utils xmlto help2man libglib2.0-dev lzop gperf python-svn libacl1-dev
+sudo locale-gen en_US.UTF-8 en_US

--- a/setup/ubuntu_15.04
+++ b/setup/ubuntu_15.04
@@ -1,2 +1,3 @@
 # Ubuntu 15.04
 sudo apt-get --yes install python-support python-magic python-pycurl python-pkg-resources python-dev coreutils sed git-core cvs subversion quilt gawk texinfo automake autoconf autopoint libtool curl texi2html diffstat openjade groff mtd-utils build-essential make gcc g++ binutils bison flex bc ncurses-dev zip unzip lzma gtk-doc-tools docbook-utils libxml2-utils xmlto help2man libglib2.0-dev lzop gperf python-svn libacl1-dev
+sudo locale-gen en_US.UTF-8 en_US


### PR DESCRIPTION
The en_US.UTF-8 locale is not generated/installed by default. But since
we have

LANG ?= "en_US.UTF-8"

in conf/shell.conf, any recipe using perl (e.g. linux-headers) ends up
spewing lots of stuff like below to the log.

perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LC_NUMERIC = "C",
        LC_COLLATE = "C",
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").

It's mostly harmless, but may distract from actual errors. I don't know
if this is an issue on other distributions, nor how to fix it there.
