### PR TITLE
All the way to parallel tasks, and a little beyond

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -259,6 +259,7 @@ class OEliteBaker:
     def bake(self):
 
         self.setup_tmpdir()
+        oelite.profiling.init(self.config)
 
         # task(s) to do
         if self.options.task:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -11,6 +11,7 @@ import oelite.task
 import oelite.item
 from oelite.parse import *
 from oelite.cookbook import CookBook
+import oelite.profiling
 
 import oelite.fetch
 
@@ -89,6 +90,7 @@ def add_show_parser_options(parser):
 
 class OEliteBaker:
 
+    @oelite.profiling.profile_rusage_delta
     def __init__(self, options, args, config):
         self.options = options
         self.debug = self.options.debug

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -569,13 +569,17 @@ class OEliteBaker:
 
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
-        task = self.runq.get_runabletask()
         rusage = oelite.profiling.Rusage("Build")
         total = self.runq.number_of_tasks_to_build()
         count = 0
         exitcode = 0
+        pending = []
         failed_task_list = []
-        while task:
+        while True:
+            pending += self.runq.get_runabletasks()
+            if not pending:
+                break
+            task = pending.pop()
             count += 1
             debug("")
             debug("Preparing %s"%(task))
@@ -592,7 +596,6 @@ class OEliteBaker:
                 task.build_failed()
                 # FIXME: support command-line option to abort on first
                 # failed task
-            task = self.runq.get_runabletask()
         rusage.end()
 
         if exitcode:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -244,7 +244,7 @@ class OEliteBaker:
             self.runq = OEliteRunQueue(self.config, self.cookbook)
             self.runq._add_recipe(recipe, task)
             task = self.cookbook.get_task(recipe=recipe, name=task)
-            task.prepare(self.runq)
+            task.prepare()
             meta = task.meta()
         else:
             meta = recipe.meta
@@ -579,7 +579,7 @@ class OEliteBaker:
             count += 1
             debug("")
             debug("Preparing %s"%(task))
-            task.prepare(self.runq)
+            task.prepare()
             meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -593,22 +593,21 @@ class OEliteBaker:
                 self.runq.mark_done(task)
             else:
                 err("%s failed"%(task))
-                exitcode = 1
                 failed_task_list.append(task)
                 task.build_failed()
                 # FIXME: support command-line option to abort on first
                 # failed task
         rusage.end()
 
-        if exitcode:
-             for task in failed_task_list:
-                print "\nERROR: %s failed  %s"%(task,task.logfn)
-                if self.debug_loglines:
-                    with open(task.logfn, 'r') as fin:
-                        if self.debug_loglines < 0:
-                            print fin.read()
-                        else:
-                            print ''.join(fin.readlines()[-self.debug_loglines:])
+        for task in failed_task_list:
+            exitcode = 1
+            print "\nERROR: %s failed  %s"%(task,task.logfn)
+            if self.debug_loglines:
+                with open(task.logfn, 'r') as fin:
+                    if self.debug_loglines < 0:
+                        print fin.read()
+                    else:
+                        print ''.join(fin.readlines()[-self.debug_loglines:])
         return exitcode
 
 

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -293,7 +293,7 @@ class OEliteBaker:
         # first, add complete dependency tree, with complete
         # task-to-task and task-to-package/task dependency information
         debug("Building dependency tree")
-        start = oelite.util.now()
+        rusage = oelite.profiling.Rusage("Building dependency tree")
         for task in self.tasks_todo:
             task = oelite.task.task_name(task)
             try:
@@ -311,7 +311,7 @@ class OEliteBaker:
                 die("No such task: %s: %s"%(thing, e.__str__()))
             except oebakery.FatalError, e:
                 die("Failed to add %s:%s to runqueue"%(thing, task))
-        oelite.util.timing_info("Building dependency tree", start)
+        rusage.end()
 
         # Generate recipe dependency graph
         recipes = set([])
@@ -359,7 +359,7 @@ class OEliteBaker:
         task = self.runq.get_metahashable_task()
         total = self.runq.number_of_runq_tasks()
         count = 0
-        start = oelite.util.now()
+        rusage = oelite.profiling.Rusage("Calculating task metadata hashes")
         while task:
             oelite.util.progress_info("Calculating task metadata hashes",
                                       total, count)
@@ -433,7 +433,7 @@ class OEliteBaker:
         oelite.util.progress_info("Calculating task metadata hashes",
                                   total, count)
 
-        oelite.util.timing_info("Calculation task metadata hashes", start)
+        rusage.end()
 
         if count != total:
             print ""
@@ -570,7 +570,7 @@ class OEliteBaker:
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
         task = self.runq.get_runabletask()
-        start = oelite.util.now()
+        rusage = oelite.profiling.Rusage("Build")
         total = self.runq.number_of_tasks_to_build()
         count = 0
         exitcode = 0
@@ -594,7 +594,7 @@ class OEliteBaker:
                 # FIXME: support command-line option to abort on first
                 # failed task
             task = self.runq.get_runabletask()
-        oelite.util.timing_info("Build", start)
+        rusage.end()
 
         if exitcode:
              for task in failed_task_list:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -591,7 +591,12 @@ class OEliteBaker:
                     continue
                 task = pending.pop()
                 oven.start(task)
-                oven.wait_task(False, task)
+                # After starting a task, always do an immediate poll -
+                # if it was a synchronous task, it is already done by
+                # the time oven.start() returns, so it might as well get
+                # removed from the oven and its dependents made
+                # eligible.
+                oven.wait_task(True, task)
         finally:
             oven.wait_all(False)
 

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -610,7 +610,6 @@ class OEliteBaker:
                         print ''.join(fin.readlines()[-self.debug_loglines:])
         return exitcode
 
-
     def setup_tmpdir(self):
 
         tmpdir = os.path.realpath(self.config.get("TMPDIR", 1) or "tmp")

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -21,7 +21,6 @@ import sys
 import os
 import glob
 import shutil
-import datetime
 import hashlib
 import logging
 
@@ -294,7 +293,7 @@ class OEliteBaker:
         # first, add complete dependency tree, with complete
         # task-to-task and task-to-package/task dependency information
         debug("Building dependency tree")
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         for task in self.tasks_todo:
             task = oelite.task.task_name(task)
             try:
@@ -360,7 +359,7 @@ class OEliteBaker:
         task = self.runq.get_metahashable_task()
         total = self.runq.number_of_runq_tasks()
         count = 0
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         while task:
             oelite.util.progress_info("Calculating task metadata hashes",
                                       total, count)
@@ -571,7 +570,7 @@ class OEliteBaker:
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
         task = self.runq.get_runabletask()
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         total = self.runq.number_of_tasks_to_build()
         count = 0
         exitcode = 0

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -602,7 +602,16 @@ class OEliteBaker:
                 # the time oven.start() returns, so it might as well get
                 # removed from the oven and its dependents made
                 # eligible.
-                oven.wait_task(True, task)
+                #
+                # Rather than doing oven.wait_task(True, task), we
+                # actually do a (single) poll for every task in the
+                # oven. This is necessary to ensure that an important
+                # task such as glibc:do_configure doesn't lie around
+                # as a zombie while we do lots of do_fetch etc. - we
+                # want the glibc recipe to proceed as fast as
+                # possible, so that other recipes'
+                # do_stage,do_configure and so on become eligible.
+                oven.wait_all(True)
         finally:
             oven.wait_all(False)
 

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -607,6 +607,7 @@ class OEliteBaker:
             oven.wait_all(False)
 
         rusage.end()
+        oven.write_profiling_data()
 
         for task in oven.failed_tasks:
             exitcode = 1

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -578,10 +578,17 @@ class OEliteBaker:
 
         oven = OEliteOven(self, 8)
         try:
-            while True:
+            while oven.count < oven.total:
                 pending += self.runq.get_runabletasks()
-                if not pending:
-                    break
+                if not pending or oven.capacity <= 0:
+                    # If we have no runable tasks and nothing in the
+                    # oven, some tasks must have failed.
+                    if not oven.currently_baking():
+                        break
+                    # Gotta wait for some task to finish. That may
+                    # make some new task eligible.
+                    oven.wait_any(False)
+                    continue
                 task = pending.pop()
                 oven.start(task)
                 oven.wait_task(False, task)

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -569,6 +569,8 @@ class OEliteBaker:
 
         # FIXME: add some kind of statistics, with total_tasks,
         # prebaked_tasks, running_tasks, failed_tasks, done_tasks
+        #
+        # FIXME: add back support for options.fake_build
         rusage = oelite.profiling.Rusage("Build")
         total = self.runq.number_of_tasks_to_build()
         count = 0
@@ -586,7 +588,7 @@ class OEliteBaker:
             task.prepare()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()
-            if self.options.fake_build or task.run():
+            if task.run():
                 task.build_done(self.runq.get_task_buildhash(task))
                 self.runq.mark_done(task)
             else:

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -580,7 +580,6 @@ class OEliteBaker:
             debug("")
             debug("Preparing %s"%(task))
             task.prepare()
-            meta = task.meta()
             info("Running %d / %d %s"%(count, total, task))
             task.build_started()
             if self.options.fake_build or task.run():

--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -580,7 +580,7 @@ class OEliteBaker:
         pending = PriorityQueue(initial = self.runq.get_runabletasks(),
                                 key = lambda t: (-t.recipe.build_prio, t.recipe.remaining_tasks))
 
-        oven = OEliteOven(self, 8)
+        oven = OEliteOven(self)
         try:
             while oven.count < oven.total:
                 new_runable = self.runq.get_runabletasks()

--- a/lib/oelite/compat.py
+++ b/lib/oelite/compat.py
@@ -2,7 +2,6 @@
 import os
 import fcntl
 import ctypes
-import datetime
 import sys
 
 __all__ = ["dup_cloexec", "open_cloexec"]

--- a/lib/oelite/compat.py
+++ b/lib/oelite/compat.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+import os
+import fcntl
+import ctypes
+import datetime
+import sys
+
+__all__ = ["dup_cloexec", "open_cloexec"]
+
+# uname() -> (sysname, nodename, release, version, machine)
+sysname, _, release, _, machine = os.uname()
+
+values = dict()
+if (sysname, machine) == ("Linux", "x86_64"):
+    # these are supported since at least 2.6.24, so just set them unconditionally
+    values['O_CLOEXEC'] = 02000000
+    values['F_DUPFD_CLOEXEC'] = 1024+6
+
+# import bb.utils doesn't work when we try to run this by itself (to
+# test it), so this just serves to show what one could do, provided
+# someone figures out how to make the vercmp_string available.
+#
+# elif sysname == "FreeBSD":
+#     if bb.utils.vercmp_string(release, "8.3") >= 0:
+#         values['O_CLOEXEC'] = 0x00100000
+#     if bb.utils.vercmp_string(release, "9.2") >= 0:
+#         values['F_DUPFD_CLOEXEC'] = 17
+
+def dup_cloexec(fd):
+    return fcntl.fcntl(fd, F_DUPFD_CLOEXEC, 0)
+
+def open_cloexec(filename, flag, mode=0777):
+    return os.open(filename, flag | O_CLOEXEC, mode)
+
+def set_cloexec(fd):
+    fcntl.fcntl(fd, fcntl.F_SETFD, fcntl.FD_CLOEXEC)
+    return fd
+
+def dup_cloexec_fallback(fd):
+    return set_cloexec(os.dup(fd))
+
+def open_cloexec_fallback(filename, flag, mode=0777):
+    return set_cloexec(os.open(filename, flag, mode))
+
+if hasattr(os, "O_CLOEXEC"):
+    O_CLOEXEC = os.O_CLOEXEC
+else:
+    try:
+        O_CLOEXEC = values["O_CLOEXEC"]
+    except KeyError:
+        open_cloexec = open_cloexec_fallback
+
+if hasattr(fcntl, "F_DUPFD_CLOEXEC"):
+    F_DUPFD_CLOEXEC = fcntl.F_DUPFD_CLOEXEC
+else:
+    try:
+        F_DUPFD_CLOEXEC = values["F_DUPFD_CLOEXEC"]
+    except KeyError:
+        dup_cloexec = dup_cloexec_fallback
+
+
+def has_cloexec(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
+    return (flags & fcntl.FD_CLOEXEC) != 0
+
+def test_open_cloexec():
+    fd = open_cloexec("/dev/null", os.O_RDONLY)
+    assert(has_cloexec(fd))
+    os.close(fd)
+    fd = open_cloexec("/dev/null", os.O_WRONLY)
+    assert(has_cloexec(fd))
+    os.close(fd)
+
+def test_dup_cloexec():
+    fd = dup_cloexec(sys.stdin.fileno())
+    assert(has_cloexec(fd))
+    os.close(fd)
+
+
+if __name__ == "__main__":
+    test_open_cloexec()
+    test_dup_cloexec()

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -10,6 +10,7 @@ import oelite.meta
 import oelite.package
 import oelite.path
 import bb.utils
+import oelite.profiling
 
 import sys
 import os
@@ -23,7 +24,7 @@ from collections import Mapping
 
 class CookBook(Mapping):
 
-
+    @oelite.profiling.profile_rusage_delta
     def __init__(self, baker):
         self.baker = baker
         self.config = baker.config
@@ -44,6 +45,7 @@ class CookBook(Mapping):
         recipefiles = self.list_recipefiles()
         total = len(recipefiles)
         count = 0
+        rusage = oelite.profiling.Rusage("recipe parsing")
         for recipefile in recipefiles:
             count += 1
             if self.debug:
@@ -73,6 +75,7 @@ class CookBook(Mapping):
                 err("Uncaught Python exception in %s"%(
                         self.shortfilename(recipefile)))
                 fail = True
+        rusage.end()
         if fail:
             die("Errors while adding recipes to cookbook")
 

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -21,7 +21,6 @@ from types import *
 from pysqlite2 import dbapi2 as sqlite
 from collections import Mapping
 
-
 class CookBook(Mapping):
 
     @oelite.profiling.profile_rusage_delta
@@ -791,7 +790,7 @@ class CookBook(Mapping):
                 type = (recipe.meta.get("PACKAGE_TYPE_" + package) or
                         recipe.meta.get("RECIPE_TYPE"))
                 package_id = self.add_package(recipe, package, type, arch)
-            
+
                 provides = recipe.meta.get("PROVIDES_" + package) or ""
                 provides = provides.split()
                 if not package in provides:
@@ -800,7 +799,7 @@ class CookBook(Mapping):
                     self.dbc.execute(
                         "INSERT INTO provide (package, item) "
                         "VALUES (?, ?)", (package_id, item))
-            
+
                 for deptype in ("DEPENDS", "RDEPENDS"):
                     depends = recipe.meta.get("%s_%s"%(deptype , package)) or ""
                     for item in depends.split():
@@ -848,3 +847,31 @@ class CookBook(Mapping):
             "SELECT item FROM package_depend "
             "WHERE deptype=? "
             "AND package=?", (deptype, package.id)))
+
+    def compute_recipe_build_priorities(self):
+        recipes = self.recipes.values()
+        # The dependencies are available as r.recipe_deps. We don't
+        # need to mutate those sets for descendants computations, so
+        # we just take an extra reference.
+        parents = dict()
+        children = dict()
+        descendants = dict()
+        for r in recipes:
+            parents[r] = r.recipe_deps
+            children[r] = set([])
+            descendants[r] = set([r])
+        for c in children:
+            for p in parents[c]:
+                children[p].add(c)
+        childless = [r for r in children if len(children[r]) == 0]
+        while childless:
+            c = childless.pop()
+            for p in parents[c]:
+                descendants[p].update(descendants[c])
+                children[p].remove(c)
+                if not children[p]:
+                    childless.append(p)
+            c.build_prio = len(descendants[c])
+            c.remaining_tasks = len(c.tasks)
+            del descendants[c]
+        assert(len(descendants) == 0)

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -98,6 +98,7 @@ class PythonFunction(OEliteFunction):
         eval(self.code, g, l)
         self.function = l[var]
         self.set_os_environ = set_os_environ
+        self.result = False
         super(PythonFunction, self).__init__(meta, var, name, tmpdir)
         return
 

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import warnings
 import re
+import subprocess
 
 class OEliteFunction(object):
 
@@ -120,6 +121,28 @@ class ShellFunction(OEliteFunction):
         super(ShellFunction, self).__init__(meta, var, name, tmpdir)
         return
 
+    def runscript(self, cmd):
+        cmdstr = cmd
+        cmdname = cmd.split(None, 1)[0]
+
+        print '> %s'%(cmdstr,)
+
+        try:
+            retval = None
+            returncode = subprocess.call(cmd, stdin=sys.stdin, shell=True)
+            if returncode == 0:
+                retval = True
+            else:
+                print "Error: Command failed: %r: %d"%(cmdstr, returncode)
+        except OSError, e:
+            if e.errno == 2:
+                print "Error: Command not found:", cmdname
+            else:
+                print "Error: Command failed: %r"%(cmdstr)
+
+        return retval
+
+
     def __call__(self):
         runfn = "%s/%s.%s.run" % (self.tmpdir, self.name, self.meta.get("DATETIME"))
         runsymlink = "%s/%s.run" % (self.tmpdir, self.name)
@@ -174,4 +197,4 @@ class ShellFunction(OEliteFunction):
         if self.meta.get_flag(self.name, "fakeroot"):
             cmd = "%s "%(self.meta.get("FAKEROOT") or "fakeroot") + cmd
         cmd = "LC_ALL=C " + cmd
-        return oelite.util.shcmd(cmd)
+        return self.runscript(cmd)

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -23,7 +23,6 @@ class OEliteFunction(object):
             self.tmpdir = self.meta.get("T")
             if not self.tmpdir:
                 die("T variable not set, unable to build")
-        self.flags = meta.get_flags(var, oelite.meta.FULL_EXPANSION)
         return
 
     def __str__(self):

--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -33,6 +33,10 @@ class OEliteFunction(object):
         return "OEliteFunction(%s)"%(self.var)
 
     def run(self, cwd):
+        self.start(cwd)
+        return self.wait(False)
+
+    def start(self, cwd):
         # Change directory
         old_cwd = os.getcwd()
         os.chdir(cwd)
@@ -44,18 +48,24 @@ class OEliteFunction(object):
             umask = int(self.meta.get("DEFAULT_UMASK"), 8)
         old_umask = os.umask(umask)
         try:
-            return self()
+            self._start()
         finally:
             # Restore directory
             os.chdir(old_cwd)
             # Restore umask
             os.umask(old_umask)
 
+    def _start(self):
+        self.result = self()
+
+    def wait(self, poll=False):
+        return self.result
+
 
 class NoopFunction(OEliteFunction):
 
-    def run(self, cwd):
-        return True
+    def start(self, cwd):
+        self.result = True
     
 
 class PythonFunction(OEliteFunction):

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -85,6 +85,7 @@ class OEliteOven:
             return None
         delta = self.remove(task)
 
+        task.recipe.remaining_tasks -= 1
         if result:
             info("%s finished - %s s" % (task, delta))
             task.build_done(self.baker.runq.get_task_buildhash(task))

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -1,0 +1,127 @@
+import oebakery
+from oebakery import die, err, warn, info, debug
+from oelite import *
+from recipe import OEliteRecipe
+from runq import OEliteRunQueue
+import oelite.meta
+import oelite.util
+import oelite.arch
+import oelite.parse
+import oelite.task
+import oelite.item
+from oelite.parse import *
+from oelite.cookbook import CookBook
+
+import oelite.fetch
+
+import bb.utils
+
+import sys
+import os
+import glob
+import shutil
+import hashlib
+import logging
+import time
+
+class OEliteOven:
+    def __init__(self, baker, capacity):
+        self.capacity = capacity
+        self.baker = baker
+        self.starttime = dict()
+        self.failed_tasks = []
+        self.total = baker.runq.number_of_tasks_to_build()
+        self.count = 0
+
+    # The tasks which are currently baking are the keys in the
+    # .starttime member. Implementing __contains__ makes sense of
+    # "task in oven".
+    def __contains__(self, x):
+        return x in self.starttime
+
+    # Allow "for t in oven:"
+    def __iter__(self):
+        return iter(self.starttime)
+
+    # Size of oven == number of currently baking tasks.
+    def __len__(self):
+        return len(self.starttime)
+
+    def currently_baking(self):
+        return list(self)
+
+    def add(self, task):
+        self.capacity -= task.weight
+        self.starttime[task] = oelite.util.now()
+
+    def remove(self, task):
+        now = oelite.util.now()
+        delta = now - self.starttime[task]
+        del self.starttime[task]
+        self.capacity += task.weight
+        return delta
+
+    def start(self, task):
+        self.add(task)
+
+        self.count += 1
+        debug("")
+        debug("Preparing %s"%(task))
+        task.prepare()
+        info("%s started - %d / %d "%(task, self.count, self.total))
+        task.build_started()
+
+        task.start()
+
+    def wait_task(self, poll, task):
+        """Wait for a specific task to finish baking. Returns pair (result,
+        delta), or None in case poll=True and the task is not yet
+        done.
+
+        """
+        assert(task in self)
+        result = task.wait(poll)
+        if result is None:
+            return None
+        delta = self.remove(task)
+
+        if result:
+            info("%s finished - %s s" % (task, delta))
+            task.build_done(self.baker.runq.get_task_buildhash(task))
+            self.baker.runq.mark_done(task)
+        else:
+            err("%s failed - %s s" % (task, delta))
+            self.failed_tasks.append(task)
+            task.build_failed()
+
+        return (task, result, delta)
+
+    def wait_any(self, poll):
+        """Wait for any task currently in the oven to finish. Returns triple
+        (task, result, time), or None.
+
+        """
+        if not poll and len(self) == 0:
+            raise Exception("nothing in the oven, so you'd wait forever...")
+        tasks = self.currently_baking()
+        tasks.sort(key=lambda t: self.starttime[t])
+        while True:
+            for t in tasks:
+                result = self.wait_task(True, t)
+                if result is not None:
+                    return result
+            if poll:
+                break
+            time.sleep(0.1)
+        return None
+
+    def wait_all(self, poll):
+        """Do wait_task once for every task currently in the oven once. With
+        poll=False, this amounts to waiting for every current task to
+        finish.
+
+        """
+        tasks = self.currently_baking()
+        tasks.sort(key=lambda t: self.starttime[t])
+        for t in tasks:
+            self.wait_task(poll, t)

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -33,6 +33,7 @@ class OEliteOven:
         self.total = baker.runq.number_of_tasks_to_build()
         self.count = 0
         self.task_stat = dict()
+        self.stdout_isatty = os.isatty(sys.stdout.fileno())
 
     # The tasks which are currently baking are the keys in the
     # .starttime member. Implementing __contains__ makes sense of
@@ -115,6 +116,7 @@ class OEliteOven:
             raise Exception("nothing in the oven, so you'd wait forever...")
         tasks = self.currently_baking()
         tasks.sort(key=lambda t: self.starttime[t])
+        i = 0
         while True:
             for t in tasks:
                 result = self.wait_task(True, t)
@@ -122,6 +124,12 @@ class OEliteOven:
                     return result
             if poll:
                 break
+            i += 1
+            if i == 4 and self.stdout_isatty:
+                info("waiting for any of these to finish:")
+                now = oelite.util.now()
+                for t in tasks:
+                    info("  %-40s started %6.2f s ago" % (t, now-self.starttime[t]))
             time.sleep(0.1)
         return None
 

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -25,7 +25,13 @@ import logging
 import time
 
 class OEliteOven:
-    def __init__(self, baker, capacity):
+    def __init__(self, baker, capacity=None):
+        if capacity is None:
+            pmake = baker.config.get("PARALLEL_MAKE")
+            if pmake is None or pmake == "":
+                capacity = 3
+            else:
+                capacity = int(pmake.replace("-j", "")) + 2
         self.capacity = capacity
         self.baker = baker
         self.starttime = dict()

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -78,8 +78,6 @@ class OEliteOven:
         return delta
 
     def start(self, task):
-        self.add(task)
-
         self.count += 1
         debug("")
         debug("Preparing %s"%(task))
@@ -87,6 +85,7 @@ class OEliteOven:
         info("%s started - %d / %d "%(task, self.count, self.total))
         task.build_started()
 
+        self.add(task)
         task.start()
 
     def wait_task(self, poll, task):

--- a/lib/oelite/oven.py
+++ b/lib/oelite/oven.py
@@ -115,6 +115,12 @@ class OEliteOven:
         if not poll and len(self) == 0:
             raise Exception("nothing in the oven, so you'd wait forever...")
         tasks = self.currently_baking()
+        if not poll and len(tasks) == 1:
+            t = tasks[0]
+            if self.stdout_isatty:
+                now = oelite.util.now()
+                info("waiting for %s (started %6.2f ago) to finish" % (t, now-self.starttime[t]))
+            return self.wait_task(False, t)
         tasks.sort(key=lambda t: self.starttime[t])
         i = 0
         while True:

--- a/lib/oelite/priq.py
+++ b/lib/oelite/priq.py
@@ -1,0 +1,25 @@
+import heapq
+
+class PriorityQueue:
+    def __init__(self, initial=None, key=lambda x:x):
+       self.key = key
+       self.serial = 0
+       if initial:
+           self._data = [(key(item), self.nextserial(), item) for item in initial]
+           heapq.heapify(self._data)
+       else:
+           self._data = []
+
+    def nextserial(self):
+        ret = self.serial
+        self.serial += 1
+        return ret
+
+    def push(self, item):
+        heapq.heappush(self._data, (self.key(item), self.nextserial(), item))
+
+    def pop(self):
+        return heapq.heappop(self._data)[2]
+
+    def __len__(self):
+        return len(self._data)

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -1,0 +1,192 @@
+import datetime
+import functools
+import atexit
+import oelite.util
+import inspect
+import os
+import sys
+from resource import *
+
+now = datetime.datetime.utcnow
+
+profiledir = None
+
+def profile_output(name, mode="a"):
+    if profiledir:
+        path = os.path.join(profiledir, name)
+    else:
+        path = "/dev/null"
+    return open(path, mode)
+
+# Decorating any function with @profile_calls will record the duration
+# of every call of that function. Some statistics on these are
+# automatically printed to $profiledir/callstats.txt on exit.
+profiled_functions = dict()
+def profile_calls(somefunc):
+    @functools.wraps(somefunc)
+    def recordtime(*args, **kwargs):
+        start = now()
+        try:
+            return somefunc(*args, **kwargs)
+        finally:
+            delta = (now()-start).total_seconds()
+            if not somefunc in profiled_functions:
+                profiled_functions[somefunc] = SimpleStats()
+            profiled_functions[somefunc].append(delta)
+    return recordtime
+
+def write_call_stats():
+    with profile_output("call_stats.txt") as out:
+        for f in sorted(profiled_functions.keys(), key=lambda x: x.__name__):
+            name = f.__name__
+            try:
+                srcfile = os.path.basename(inspect.getsourcefile(f))
+            except TypeError:
+                srcfile = "<unknown>"
+
+            stats = profiled_functions[f]
+            stats.compute()
+            out.write("%-12s\t%-24s\t%9.3fs / %5d = %7.3f " %
+                    (srcfile, f.__name__,
+                     stats.sum, stats.count, stats.mean))
+            out.write("[%s]\n" % ", ".join(["%7.3f" % x for x in stats.quartiles]))
+
+# For detailed profiling of individual phases (recipe parsing, hash
+# computation, entire build, ...) - records memory information as well
+# as wallclock, user and system times.
+class Rusage:
+    rusage_names = [
+        ("wtime",     "wallclock time", "%7.3f"),
+        ("ru_stime",  "system time   ", "%7.3f"),
+        ("ru_utime",  "user time     ", "%7.3f"),
+        ("ru_minflt", "minor faults  ", "%7d"),
+        ("ru_majflt", "major faults  ", "%7d"),
+        ("ru_maxrss", "max RSS       ", "%7d KiB"),
+        ("ru_nvcsw",  "context switches, voluntary  ", "%7d"),
+        ("ru_nivcsw", "context switches, involuntary", "%7d"),
+    ]
+    # For recording deltas before profiledir is created
+    deferred = []
+
+    def compute_delta(self):
+        delta = dict()
+        for m,_,_ in Rusage.rusage_names:
+            delta[m] = self.after[m] - self.before[m]
+        delta['wtime'] = delta['wtime'].total_seconds()
+        self.delta = delta
+
+    @classmethod
+    def current_rusage(self):
+        # Reading /proc/self/status, in particular the VmPeak and
+        # VmSize fields, may also be interesting.
+        x = getrusage(RUSAGE_SELF)
+        y = dict([(m, getattr(x, m)) for m,_,_ in self.rusage_names if m.startswith("ru_")])
+        y["wtime"] = now()
+        return y
+
+    def print_delta(self):
+        self.compute_delta()
+        with profile_output("rusage_delta.txt") as f:
+            f.write("%s:\n" % self.name)
+            for key, name, fmt in self.rusage_names:
+                f.write(("  %s " + fmt + "\n") % (name, self.delta[key]))
+            f.write("\n")
+
+    @classmethod
+    def print_deferred(self):
+        for p in self.deferred:
+            p.print_delta()
+
+    def __init__(self, name):
+        self.name = name
+        self.start()
+
+    def start(self):
+        self.before = self.current_rusage()
+
+    def end(self):
+        self.after = self.current_rusage()
+
+        if profiledir:
+            self.print_delta()
+        else:
+            Rusage.deferred.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.end()
+
+# For easy automatic 10000 foot profiling of run-once (or run rarely)
+# functions, just decorate it with
+#
+# @oelite.profiling.profile_rusage_delta
+def profile_rusage_delta(somefunc):
+    @functools.wraps(somefunc)
+    def recorddelta(*args, **kwargs):
+        name = somefunc.__name__
+        try:
+            srcfile = os.path.basename(inspect.getsourcefile(somefunc))
+        except TypeError:
+            srcfile = "<unknown>"
+        try:
+            lineno = str(inspect.getsourcelines(somefunc)[1])
+        except:
+            lineno = "?"
+        with Rusage("%s:%s:%s" % (srcfile, lineno, name)):
+            return somefunc(*args, **kwargs)
+    return recorddelta
+
+def write_basic_info(config):
+    with profile_output("info.txt") as f:
+        f.write("argv: %s\n" % " ".join(sys.argv))
+        f.write("PARALLEL_MAKE: %s\n" % (config.get("PARALLEL_MAKE") or ""))
+
+def init(config):
+    global profiledir
+    profiledir = os.path.join(config.get("TMPDIR"), "profiling", config.get("DATETIME"))
+    oelite.util.makedirs(profiledir)
+    linkpath = os.path.join(config.get("TMPDIR"), "profiling", "latest")
+    try:
+        os.unlink(linkpath)
+    except OSError:
+        pass
+    os.symlink(config.get("DATETIME"), linkpath)
+
+    write_basic_info(config)
+    Rusage.print_deferred()
+
+    atexit.register(write_call_stats)
+
+class SimpleStats:
+    def __init__(self):
+        self.data = []
+
+    def append(self, val):
+        self.data.append(val)
+
+    def compute(self):
+        self.data.sort()
+        self.sum = sum(self.data)
+        self.count = len(self.data)
+        try:
+            self.mean = self.sum / len(self.data)
+        except ZeroDivisionError:
+            self.mean = float('nan')
+        self.quartiles = [self.percentile(p) for p in (0,25,50,75,100)]
+
+    def percentile(self, p):
+        if len(self.data) == 0:
+            return float('nan')
+        elif len(self.data) == 1:
+            return self.data[0]
+        p = float(p)
+        if p < 0.0 or p > 100.0:
+            raise ValueError("p outside valid range")
+        p /= 100.0
+        p *= len(self.data)-1
+        i = int(p)
+        if i == len(self.data)-1:
+            return self.data[-1]
+        return (p-i)*(self.data[i+1]-self.data[i]) + self.data[i]

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -5,6 +5,7 @@ import oelite.util
 import inspect
 import os
 import sys
+import subprocess
 from resource import *
 
 now = time.time
@@ -143,6 +144,14 @@ def write_basic_info(config):
     with profile_output("info.txt") as f:
         f.write("argv: %s\n" % " ".join(sys.argv))
         f.write("PARALLEL_MAKE: %s\n" % (config.get("PARALLEL_MAKE") or ""))
+        for layer in (config.get("OESTACK") or "").split():
+            layer = layer.split(";")[0]
+            cmd = "cd %s && git describe --long --dirty --abbrev=10 --tags --always" % layer
+            try:
+                desc = subprocess.check_output(cmd, shell=True)
+            except subprocess.CalledProcessError:
+                desc = "unknown\n"
+            f.write("%s: %s" % (layer, desc))
 
 def init(config):
     global profiledir

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -85,7 +85,6 @@ class Rusage:
         return y
 
     def print_delta(self):
-        self.compute_delta()
         with profile_output("rusage_delta.txt") as f:
             f.write("%s:\n" % self.name)
             for key, name, fmt in self.rusage_names:
@@ -97,9 +96,10 @@ class Rusage:
         for p in self.deferred:
             p.print_delta()
 
-    def __init__(self, name):
+    def __init__(self, name, print_walltime=True):
         self.name = name
         self.start()
+        self.print_walltime = print_walltime
 
     def start(self):
         self.before = self.current_rusage()
@@ -108,11 +108,14 @@ class Rusage:
     def end(self):
         oelite.util.stracehack("end:" + self.name)
         self.after = self.current_rusage()
+        self.compute_delta()
 
         if profiledir:
             self.print_delta()
         else:
             Rusage.deferred.append(self)
+        if self.print_walltime:
+            print "%s: %s" % (self.name, oelite.util.pretty_time(self.delta['wtime']))
 
     def __enter__(self):
         return self
@@ -136,7 +139,7 @@ def profile_rusage_delta(somefunc):
             lineno = str(inspect.getsourcelines(somefunc)[1])
         except:
             lineno = "?"
-        with Rusage("%s:%s:%s" % (srcfile, lineno, name)):
+        with Rusage("%s:%s:%s" % (srcfile, lineno, name), print_walltime=False):
             return somefunc(*args, **kwargs)
     return recorddelta
 

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -1,4 +1,4 @@
-import datetime
+import time
 import functools
 import atexit
 import oelite.util
@@ -7,7 +7,7 @@ import os
 import sys
 from resource import *
 
-now = datetime.datetime.utcnow
+now = time.time
 
 profiledir = None
 
@@ -29,7 +29,7 @@ def profile_calls(somefunc):
         try:
             return somefunc(*args, **kwargs)
         finally:
-            delta = (now()-start).total_seconds()
+            delta = now()-start
             if not somefunc in profiled_functions:
                 profiled_functions[somefunc] = SimpleStats()
             profiled_functions[somefunc].append(delta)
@@ -72,7 +72,6 @@ class Rusage:
         delta = dict()
         for m,_,_ in Rusage.rusage_names:
             delta[m] = self.after[m] - self.before[m]
-        delta['wtime'] = delta['wtime'].total_seconds()
         self.delta = delta
 
     @classmethod

--- a/lib/oelite/profiling.py
+++ b/lib/oelite/profiling.py
@@ -103,8 +103,10 @@ class Rusage:
 
     def start(self):
         self.before = self.current_rusage()
+        oelite.util.stracehack("start:" + self.name)
 
     def end(self):
+        oelite.util.stracehack("end:" + self.name)
         self.after = self.current_rusage()
 
         if profiledir:

--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -3,6 +3,7 @@ from oelite import *
 from oelite.dbutil import *
 import oelite.util
 import oelite.recipe
+import oelite.profiling
 
 import sys
 import os
@@ -534,7 +535,8 @@ class OEliteRunQueue:
         return
 
 
-    def get_runabletask(self):
+    @oelite.profiling.profile_calls
+    def update_runabletasks(self):
         newrunable = self.get_readytasks()
         if newrunable:
             if self.depth_first:
@@ -544,6 +546,9 @@ class OEliteRunQueue:
             for task_id in newrunable:
                 task = self.cookbook.get_task(id=task_id)
                 self.set_task_pending(task)
+
+    def get_runabletask(self):
+        self.update_runabletasks()
         if not self.runable:
             return None
         task_id = self.runable.pop()

--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -8,7 +8,6 @@ import sys
 import os
 import copy
 import operator
-import datetime
 
 class OEliteRunQueue:
 
@@ -947,7 +946,7 @@ class OEliteRunQueue:
 
     def prune_runq_depends_nobuild(self):
         rowcount = 0
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         while True:
             self.dbc.execute(
                 "UPDATE runq.depend SET parent_task=NULL "
@@ -969,7 +968,7 @@ class OEliteRunQueue:
     def prune_runq_depends_with_nobody_depending_on_it(self):
         #c = self.dbc.cursor()
         rowcount = 0
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         while True:
             # The code below, until the executemany() call, implements
             # what was previously done with this horribly-performing
@@ -1001,7 +1000,7 @@ class OEliteRunQueue:
 
 
     def prune_runq_tasks(self):
-        start = datetime.datetime.now()
+        start = oelite.util.now()
         rowcount = self.dbc.execute(
             "UPDATE"
             "  runq.task "

--- a/lib/oelite/runq.py
+++ b/lib/oelite/runq.py
@@ -556,6 +556,11 @@ class OEliteRunQueue:
             return None
         return self.cookbook.get_task(id=task_id)
 
+    def get_runabletasks(self):
+        self.update_runabletasks()
+        ret = [self.cookbook.get_task(id=task_id) for task_id in self.runable]
+        self.runable = []
+        return ret
 
     def get_metahashable_task(self):
         if not self.metahashable:

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -203,9 +203,7 @@ class OEliteTask:
         os.symlink(os.path.basename(self.logfn), self.logsymlink)
 
     def save_context(self):
-        self.old_stdin = os.dup(sys.stdin.fileno())
-        self.old_stdout = os.dup(sys.stdout.fileno())
-        self.old_stderr = os.dup(sys.stderr.fileno())
+        self.saved_stdio = oelite.util.StdioSaver()
 
     def apply_context(self):
         os.dup2(self.stdin.fileno(), sys.stdin.fileno())
@@ -213,12 +211,7 @@ class OEliteTask:
         os.dup2(self.logfile.fileno(), sys.stderr.fileno())
 
     def restore_context(self):
-        os.dup2(self.old_stdin, sys.stdin.fileno())
-        os.dup2(self.old_stdout, sys.stdout.fileno())
-        os.dup2(self.old_stderr, sys.stderr.fileno())
-        os.close(self.old_stdin)
-        os.close(self.old_stdout)
-        os.close(self.old_stderr)
+        self.saved_stdio.restore(True)
 
     def cleanup_context(self):
         self.stdin.close()

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -31,11 +31,17 @@ class OEliteTask:
         self.debug = self.cookbook.debug
         self._meta = None
         self.result = None
+        self.weight = self.get_weight()
         return
 
     def __str__(self):
         return "%s:%s"%(self.recipe, self.name)
 
+    def get_weight(self):
+        # Should depend on whether this is do_compile or something
+        # else, and could also be overridden from recipe data. For
+        # now, keep it simple.
+        return 1
 
     def get_parents(self):
         parents = flatten_single_column_rows(self.cookbook.dbc.execute(

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -117,7 +117,7 @@ class OEliteTask:
             os.remove(hashpath)
 
 
-    def prepare(self, runq):
+    def prepare(self):
         meta = self.meta()
 
         buildhash = self.cookbook.baker.runq.get_task_buildhash(self)

--- a/lib/oelite/task.py
+++ b/lib/oelite/task.py
@@ -257,12 +257,16 @@ class OEliteTask:
         return None
 
     def start(self):
+        oelite.util.stracehack("==>%s" % self.name)
         self.result = self._start()
+        oelite.util.stracehack("<==%s" % self.name)
 
     def wait(self, poll=False):
+        oelite.util.stracehack("==>%s" % self.name)
         if self.result is not None:
             # Something bad happened in start
             self.cleanup_context()
+            oelite.util.stracehack("<==%s" % self.name)
             return self.result
 
         self.save_context()
@@ -294,6 +298,7 @@ class OEliteTask:
         # we don't need to make that idempotent.
         if self.result is not None:
             self.cleanup_context()
+        oelite.util.stracehack("<==%s" % self.name)
         return self.result
 
 

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -57,6 +57,11 @@ class TeeStream:
             file.write(text)
         return
 
+def stracehack(msg):
+    try:
+        os.write(-42, msg)
+    except OSError:
+        pass
 
 def shcmd(cmd, dir=None, quiet=False, success_returncode=0,
           silent_errorcodes=[], **kwargs):

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -171,18 +171,23 @@ def touch(path, makedirs=False, truncate=False):
         os.utime(path, None)
 
 
+def pretty_time(delta):
+    milliseconds = int(1000*(delta % 1))
+    delta = int(delta)
+    seconds = delta % 60
+    minutes = delta // 60 % 60
+    hours = delta // 3600
+    if hours:
+        return "%dh%02dm%02ds"%(hours, minutes, seconds)
+    elif minutes:
+        return "%dm%02ds"%(minutes, seconds)
+    else:
+        return "%d.%03d seconds"%(seconds, milliseconds)
+
+
 def timing_info(msg, start):
     msg += " time "
-    delta = datetime.datetime.now() - start
-    hours = delta.seconds // 3600
-    minutes = delta.seconds // 60 % 60
-    seconds = delta.seconds % 60
-    milliseconds = delta.microseconds // 1000
-    if hours:
-        msg += "%dh%02dm%02ds"%(hours, minutes, seconds)
-    elif minutes:
-        msg += "%dm%02ds"%(minutes, seconds)
-    else:
-        msg += "%d.%03d seconds"%(seconds, milliseconds)
+    delta = (datetime.datetime.now() - start).total_seconds()
+    msg += pretty_time(delta)
     info(msg)
     return

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -3,8 +3,9 @@ import tarfile
 import os
 import sys
 import subprocess
-import datetime
+import time
 
+now = time.time
 
 def format_textblock(text, indent=2, width=78, first_indent=None):
     """
@@ -187,7 +188,7 @@ def pretty_time(delta):
 
 def timing_info(msg, start):
     msg += " time "
-    delta = (datetime.datetime.now() - start).total_seconds()
+    delta = now() - start
     msg += pretty_time(delta)
     info(msg)
     return


### PR DESCRIPTION
This is a complete branch getting to parallel task execution. The first 13 commits are identical to PR#168 (except for a rebase to current master).

The diffstat shows that we exclusively touch files under lib/oelite, and I've doublechecked that this doesn't change meta-data hashes (by doing oe bake world on master, checking out this branch, and seeing that oe bake world says "nothing to do").

There are admittedly some leftovers from the development (such as initially setting the oven capacity to a hardcoded 8, later changing that to something based on $PARALLEL_MAKE), and I'm open to reordering/squashing/etc. But I'm not doing that unless some reviewer finds it important and points out specific problems. AFAICT, the worst issue is the "temporary" disabling of --fake-build, which doesn't get reinstated in this series (and, in fact, I do not yet have a patch for doing that).

The speed-up for an oe bake world has consistently been 40-50% during all my testing, where I've done "rm -rf tmp/stamp/machine tmp/work/machine" between runs (i.e., I haven't rebuilt the toolchain). I suppose those numbers would be slightly smaller if one compares completely clean builds.

2016-10-10: Pushed new version, taking into account comments from mnhu (on #168) and kimrhh. Some profile writing moved from baker.py to oven.py. With --debug we now cat the log file to stdout when the task is done. oven.py implementation hopefully made slightly more descriptive.
