### PR TITLE
Some memory use reduction

### DIFF
--- a/classes/core.oeclass
+++ b/classes/core.oeclass
@@ -313,18 +313,6 @@ def core_varname_expansion(d):
             flags = d.get_flags(varname, prune_var_value=False)
             #print "flags =",flags
             for flag in flags:
-                if flag == "__overrides":
-                    overrides = flags[flag]
-                    old_overrides = d.get_flag(expanded_varname, flag)
-                    if not old_overrides:
-                        d.set_flag(expanded_varname, flag, overrides)
-                        continue
-                    for type in overrides:
-                        for override_name in overrides[type]:
-                            old_overrides[type][override_name] = \
-                                overrides[type][override_name]
-                    d.set_flag(expanded_varname, flag, old_overrides)
-                    continue
                 d.set_flag(expanded_varname, flag, flags[flag])
             del d[varname]
 

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -157,15 +157,17 @@ class DictMeta(MetaData):
 
         otype = self.OVERRIDE_TYPE[override[0]]
 
-        try:
-            self.cplx[var]["__overrides"][otype][override[1]] = val
-        except KeyError, e:
-            if e.args[0] == var:
-                self.cplx[var] = {"__overrides": [{}, {}, {}]}
-            else:
-                assert e.args[0] == "__overrides"
-                self.cplx[var]["__overrides"] = [{}, {}, {}]
-            self.cplx[var]["__overrides"][otype][override[1]] = val
+        if var in self.cplx:
+            try:
+                olist = self.cplx[var]["__overrides"]
+            except KeyError:
+                olist = self.cplx[var]["__overrides"] = [{}, {}, {}]
+        else:
+            olist = [{}, {}, {}]
+            self.cplx[var] = {"__overrides": olist}
+
+        olist[otype][override[1]] = val
+
         if var in self.smpl:
             self.cplx[var][""] = self.smpl[var]
             del self.smpl[var]

--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -161,11 +161,13 @@ class DictMeta(MetaData):
             try:
                 olist = self.cplx[var]["__overrides"]
             except KeyError:
-                olist = self.cplx[var]["__overrides"] = [{}, {}, {}]
+                olist = self.cplx[var]["__overrides"] = [None, None, None]
         else:
-            olist = [{}, {}, {}]
+            olist = [None, None, None]
             self.cplx[var] = {"__overrides": olist}
 
+        if olist[otype] is None:
+            olist[otype] = {}
         olist[otype][override[1]] = val
 
         if var in self.smpl:
@@ -214,9 +216,9 @@ class DictMeta(MetaData):
             else:
                 override_dep = set(["OVERRIDES"])
             olist = self.cplx[var]["__overrides"]
-            var_overrides = olist[self.OVERRIDE_TYPE['']]
-            append_overrides = olist[self.OVERRIDE_TYPE['>']]
-            prepend_overrides = olist[self.OVERRIDE_TYPE['<']]
+            var_overrides = olist[self.OVERRIDE_TYPE['']] or {}
+            append_overrides = olist[self.OVERRIDE_TYPE['>']] or {}
+            prepend_overrides = olist[self.OVERRIDE_TYPE['<']] or {}
             oval = None
             append = ""
             prepend = ""
@@ -312,6 +314,13 @@ class DictMeta(MetaData):
             otype = self.OVERRIDE_TYPE[override[0]]
             return self.cplx[var]["__overrides"][otype][override[1]]
         except KeyError:
+            # No var in cplx, no __overrides in cplx[var], or
+            # override[1] not in the innermost dict
+            pass
+        except TypeError:
+            # Morally, the dict at [otype] is empty, but we've used
+            # None to save memory, so we get 'NoneType' object has no
+            # attribute '__getitem__' instead of KeyError.
             pass
         return None
 


### PR DESCRIPTION
These patches reduce the (anonymous) memory footprint of the oe-lite process by about 100MiB (~14%) for an oe bake world. They do not change metadata hashes.
