### PR TITLE
oelite/meta/dict.py: don't expand python code in _fill_expand_cache

### DIFF
--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -266,7 +266,11 @@ class DictMeta(MetaData):
     def _fill_expand_cache(self):
         if self.expand_cache_filled:
             return
-        for var in self.keys():
+        for var in self.smpl:
+            self._get(var)
+        for var, val in self.cplx.iteritems():
+            if "python" in val:
+                continue
             self._get(var)
         self.expand_cache_filled = True
 


### PR DESCRIPTION
This saves another 5+ MiB of memory.
