### PR TITLE
oelite/baker.py: add --dryrun option

### DIFF
--- a/lib/oelite/baker.py
+++ b/lib/oelite/baker.py
@@ -55,6 +55,10 @@ def add_bake_parser_options(parser):
                       action="store_true", default=False,
                       help="assume 'y' response to trivial questions")
 
+    parser.add_option("--dryrun",
+                      action="store_true", default=False,
+                      help="do recipe parsing, dependency resolving etc., but do not actually bake anything")
+
     parser.add_option("--rmwork",
                       action="store_true", default=None,
                       help="clean workdir for all recipes being built")
@@ -545,6 +549,10 @@ class OEliteBaker:
             else:
                 text.append("%s:%s(%d)"%(recipe[1], recipe[2], recipe[4]))
         print oelite.util.format_textblock(" ".join(text))
+
+        if self.options.dryrun:
+            print "Dryrun, not baking"
+            return 0
 
         self.cookbook.compute_recipe_build_priorities()
 


### PR DESCRIPTION
This makes it easier to do all the initial recipe parsing, hash
computation etc. without doing an actual build - this is especially
useful if one is doing some automated testing of a series of meta/core
commits, since one doesn't have to sit and stare at the terminal for a
few minutes waiting to say 'no'. It can also be useful in
non-interactive settings, for example setting up a cheap buildbot job to
do "oe bake world --dryrun" to check that all recipes actually parse,
without doing a full build.
