### PR TITLE
url.py: Replace urlgrabber with a simple syscall to wget

### DIFF
--- a/conf/provided/default.conf
+++ b/conf/provided/default.conf
@@ -9,6 +9,5 @@ native:bzip2 \
 native:texinfo native:makeinfo native:doxygen \
 native:texlive-extra-utils native:texlive-latex-extra native:latex-xcolor \
 native:flex native:bison \
-native:wget \
 native:libacl1-dev \
 "

--- a/conf/provided/minimal.conf
+++ b/conf/provided/minimal.conf
@@ -19,4 +19,5 @@ native:python-runtime \
 native:util-linux native:coreutils \
 native:shasum \
 native:gawk native:sed native:grep \
+native:wget \
 "


### PR DESCRIPTION
The underlying problem is that pycurl in ubuntu and debian based
systems are linked with gnutls (instead of openssl)
This results in rror: gnutls_handshake() failed

Signed-off-by: Sean Nyekjaer sean.nyekjaer@prevas.dk
