### PR TITLE
readline: link with ncurses

### DIFF
--- a/recipes/readline/readline-6.2/0000-curses-link.patch
+++ b/recipes/readline/readline-6.2/0000-curses-link.patch
@@ -1,0 +1,22 @@
+link readline directly to ncurses since it needs symbols from it
+
+upstream readline does this on purpose (no direct linking), but
+it doesn't make much sense in a Linux world
+
+patch from buildroot
+Upstream-Status: Pending
+
+http://cgit.openembedded.org/openembedded-core/tree/meta/recipes-core/readline/readline-6.3/configure-fix.patch?id=b18fa5f2f2f46afc6fdc58f4d29679dea9c36c43
+https://git.busybox.net/buildroot/tree/package/readline/0000-curses-link.patch?id=5f1e0e688bba9b94287302258afdfacd6e6344e2
+
+--- a/support/shobj-conf
++++ b/support/shobj-conf
+@@ -42,7 +42,7 @@
+ SHOBJ_LIBS=
+ 
+ SHLIB_XLDFLAGS=
+-SHLIB_LIBS=
++SHLIB_LIBS=-lncurses
+ 
+ SHLIB_DOT='.'
+ SHLIB_LIBPREF='lib'

--- a/recipes/readline/readline.inc
+++ b/recipes/readline/readline.inc
@@ -3,19 +3,32 @@ HOMEPAGE = "http://www.gnu.org/software/readline/"
 
 RECIPE_TYPES = "machine native sdk"
 
-SRC_URI = "ftp://ftp.gnu.org/gnu/readline/readline-${PV}.tar.gz"
+SRC_URI = "ftp://ftp.gnu.org/gnu/readline/readline-${PV}.tar.gz \
+           ${TERMCAP_PATCH}"
+
+TERMCAP_PATCH = "file://0000-curses-link.patch"
+TERMCAP_PATCH:HOST_LIBC_mingw = ""
 
 inherit autotools make-vpath
 
 #Only used for Aarch64
 AUTOCONFDIRS = "/support"
 
+EXTRA_OECONF += "${TERMCAP_OECONF}"
+TERMCAP_OECONF = " ac_cv_lib_ncurses_tgetent=yes bash_cv_termcap_lib=libncurses"
+TERMCAP_OECONF:HOST_LIBC_mingw = ""
+
 inherit auto-package-libs
 AUTO_PACKAGE_LIBS = "readline history"
+AUTO_PACKAGE_LIBS_DEPENDS = "libc ${TERMCAP}"
+AUTO_PACKAGE_LIBS_RDEPENDS = "libc ${TERMCAP}"
 AUTO_PACKAGE_LIBS_DEV_DEPENDS = "${PN}-dev"
 AUTO_PACKAGE_LIBS_DEV_RDEPENDS = "${PN}-dev"
 
-SOLIBS:HOST_OS_mingw32 = "${@d.get('PV').split('.')[0]}.dll"
+LIBRARY_VERSION = "6"
 
-DEPENDS = "libtermcap"
-DEPENDS:HOST_OS_mingw32 = ""
+SOLIBS:HOST_LIBC_mingw = "${@d.get('PV').split('.')[0]}.dll"
+
+DEPENDS = "${TERMCAP}"
+TERMCAP = "libtermcap"
+TERMCAP:HOST_LIBC_mingw = ""


### PR DESCRIPTION
readline needs ncurses for termcap, so we actually needs to link
with it and add it to RDEPENDS.

configure for readline is broken so we have to hard add linking with
ncurses.

Signed-off-by: Sean Nyekjaer sean@nyekjaer.dk
