### PR TITLE
A minor memory reduction

### DIFF
--- a/lib/oelite/meta/dict.py
+++ b/lib/oelite/meta/dict.py
@@ -455,6 +455,13 @@ class DictMeta(MetaData):
         self.weak_set_flag(function, "emit", "")
         return
 
+    def del_hooks(self, name):
+        try:
+            del self.cplx["__hooks"][name]
+            if len(self.cplx["__hooks"]) == 0:
+                del self.cplx["__hooks"]
+        except KeyError:
+            pass
 
     def get_hooks(self, name):
         try:

--- a/lib/oelite/pyexec.py
+++ b/lib/oelite/pyexec.py
@@ -29,9 +29,9 @@ def inlineeval(source, meta, var=None):
         raise
 
 
-def exechooks(meta, name):
-    hooks = meta.get_hooks(name)
-    tmpdir = os.path.join(meta.get("HOOKTMPDIR"), name)
+def exechooks(meta, hookname, remove_hooks=True):
+    hooks = meta.get_hooks(hookname)
+    tmpdir = os.path.join(meta.get("HOOKTMPDIR"), hookname)
     oelite.util.makedirs(tmpdir)
     for function in hooks:
         pn = meta.get("PN")
@@ -46,4 +46,6 @@ def exechooks(meta, name):
             raise oelite.HookFailed(name, function, retval)
         elif not retval:
             raise oelite.HookFailed(name, function, retval)
+    if remove_hooks:
+        meta.del_hooks(hookname)
     return

--- a/lib/oelite/pyexec.py
+++ b/lib/oelite/pyexec.py
@@ -29,9 +29,8 @@ def inlineeval(source, meta, var=None):
         raise
 
 
-def exechooks(meta, name, hooks=None):
-    if hooks is None:
-        hooks = meta.get_hooks(name)
+def exechooks(meta, name):
+    hooks = meta.get_hooks(name)
     tmpdir = os.path.join(meta.get("HOOKTMPDIR"), name)
     oelite.util.makedirs(tmpdir)
     for function in hooks:


### PR DESCRIPTION
The __hooks variable is a rather complicated data structure, so we save some time and memory by avoiding copying it to the task metadata instances.