### PR TITLE
packageqa.oeclass: fix error handling

### DIFF
--- a/classes/package-qa.oeclass
+++ b/classes/package-qa.oeclass
@@ -226,7 +226,7 @@ def do_packageqa(d):
     from glob import glob
     import oebakery # die, err, warn, info, debug
 
-    def BadElfType(Exception):
+    class BadElfType(Exception):
         pass
 
     os.environ['PATH'] = d.getVar("PATH", True)


### PR DESCRIPTION
In the rare event that the ELF type is not known by libmagic there
should be a definition for the BadElfError being thrown.