### PR TITLE
package.oeclass: properly handle broken symlinks

### DIFF
--- a/classes/package.oeclass
+++ b/classes/package.oeclass
@@ -210,7 +210,8 @@ def do_package(d):
         os.system("tar cf %s/%s_%s_%s.tar ."%(outdir, package, pv, buildhash))
         srcfile = "%s_%s_%s.tar"%(package, pv, buildhash)
         symlink = "%s/%s_%s.tar"%(outdir, package, pv)
-        if os.path.exists(symlink):
+        #lexists() to make sure we also check for broken symlinks
+        if os.path.lexists(symlink):
             os.remove(symlink)
         os.symlink(srcfile, symlink)
 


### PR DESCRIPTION
If there was a broken symlink in the packages directory the code
would decide the file (the symlink) did exist, and then later fail
to replace it. Use the proper python function to handle this case.