### PR TITLE
Prepare for saner use flag handling

### DIFF
--- a/classes/chrpath.oeclass
+++ b/classes/chrpath.oeclass
@@ -18,12 +18,12 @@ CHRPATH_DIRS = "${base_bindir} ${bindir} ${base_sbindir} ${sbindir} \
 CHRPATH_REPLACE_DIRS			= "${CHRPATH_DIRS}"
 CHRPATH_STRIP_DIRS			= ""
 
-## @useflag chrpath_machine_strip When this flag is set, rpaths will be
-##          stripped from elf files of machine recipes.  When this flag is not
-##          set, rpath in elf files of machine recipes will be replaced with
+## @useflag chrpath_machine_strip When this flag is True, rpaths will be
+##          stripped from elf files of machine recipes.  When this flag is
+##          False, rpath in elf files of machine recipes will be replaced with
 ##          $ORIGIN relative paths.
 CLASS_FLAGS += "chrpath_machine_strip"
-DEFAULT_USE_chrpath_machine_strip = "1"
+DEFAULT_USE_chrpath_machine_strip = True
 MACHINE_CHRPATH_REPLACE_DIRS:USE_chrpath_machine_strip	= ""
 MACHINE_CHRPATH_STRIP_DIRS:USE_chrpath_machine_strip	= "${CHRPATH_DIRS}"
 MACHINE_CHRPATH_REPLACE_DIRS		= "${CHRPATH_DIRS}"

--- a/classes/cpio-image.oeclass
+++ b/classes/cpio-image.oeclass
@@ -13,7 +13,7 @@ inherit image image_mdev image_inetd image_crontab image_makedevs image_inittab 
 
 CLASS_FLAGS += "ramdisk_image \
     ramdisk_image_name ramdisk_image_compression"
-DEFAULT_USE_ramdisk_image = "0"
+DEFAULT_USE_ramdisk_image = False
 DEFAULT_USE_ramdisk_image_name = "${IMAGE_BASENAME}"
 DEFAULT_USE_ramdisk_image_compression = "none"
 

--- a/classes/crontab.oeclass
+++ b/classes/crontab.oeclass
@@ -13,12 +13,11 @@ require conf/crontab.conf
 CRONTAB_DEPENDS = " crond"
 RDEPENDS_${PN}:>USE_crontab = "${CRONTAB_DEPENDS}"
 
-do_install[postfuncs] += "do_install_crontab"
+DO_INSTALL_CRONTAB = ""
+DO_INSTALL_CRONTAB:USE_crontab = "do_install_crontab"
+do_install[postfuncs] += "${DO_INSTALL_CRONTAB}"
 python do_install_crontab () {
     import os
-
-    if not d.get('USE_crontab'):
-	return
 
     options = ((d.get('RECIPE_FLAGS') or "").split() +
                (d.get('CLASS_FLAGS') or "").split())

--- a/classes/gettext.oeclass
+++ b/classes/gettext.oeclass
@@ -13,7 +13,7 @@ DEPENDS_GETTEXT_NLS:USE_nls = "${DEPENDS_GETTEXT}"
 DEPENDS_GETTEXT = "host:gettext native:gettext-utils host:libiconv host:libintl"
 
 CLASS_FLAGS += "nls"
-DEFAULT_USE_nls = "0"
+DEFAULT_USE_nls = False
 EXTRA_OECONF_GETTEXT = "--disable-nls"
 EXTRA_OECONF_GETTEXT:USE_nls = "--enable-nls"
 

--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -195,7 +195,7 @@ KERNEL_UIMAGE_DEPENDS = "${@['', 'native:util/mkimage']['${USE_kernel_imagetype}
 CLASS_FLAGS += "kernel_uimage \
     kernel_uimage_entrypoint kernel_uimage_loadaddress kernel_uimage_name"
 KERNEL_UIMAGE_DEPENDS:USE_kernel_uimage = "native:util/mkimage"
-DEFAULT_USE_kernel_uimage = "0"
+DEFAULT_USE_kernel_uimage = False
 DEFAULT_USE_kernel_uimage_name = "${DISTRO}/${PV}/${MACHINE}"
 
 KERNEL_COMPILE_POSTFUNCS:>USE_kernel_uimage = " do_compile_kernel_uimage"

--- a/classes/runit.oeclass
+++ b/classes/runit.oeclass
@@ -18,14 +18,13 @@ CLASS_FLAGS += "runit"
 RDEPENDS_RUNIT ?= "runit"
 RDEPENDS_${PN}:>USE_runit = " ${RDEPENDS_RUNIT}"
 
-do_install[postfuncs] += "do_install_runit"
+DO_INSTALL_RUNIT = ""
+DO_INSTALL_RUNIT:USE_runit = "do_install_runit"
+do_install[postfuncs] += "${DO_INSTALL_RUNIT}"
 python do_install_runit () {
     import stat
     path = d.get("D")
     os.chdir(path)
-
-    if not bb.data.getVar('USE_runit', d, True):
-        return
 
     options = ((d.get("RECIPE_FLAGS") or "").split() +
                (d.get("CLASS_FLAGS") or "").split())

--- a/classes/sdk-image.oeclass
+++ b/classes/sdk-image.oeclass
@@ -66,19 +66,19 @@ RDEPENDS_SDK_LIBC_EXTRA = "target:libnss-files-dev target:libnss-dns-dev"
 RDEPENDS_SDK_LIBC_EXTRA:TARGET_LIBC_uclibc = ""
 
 CLASS_FLAGS += "sdk_cxx"
-DEFAULT_USE_sdk_cxx = "1"
+DEFAULT_USE_sdk_cxx = True
 RDEPENDS_SDK += "${RDEPENDS_SDK_CXX}"
 RDEPENDS_SDK_CXX = ""
 RDEPENDS_SDK_CXX:USE_sdk_cxx = "gcc-g++ target:libstdc++-dev"
 
 CLASS_FLAGS += "sdk_gdb"
-DEFAULT_USE_sdk_gdb = "1"
+DEFAULT_USE_sdk_gdb = True
 RDEPENDS_SDK += "${RDEPENDS_SDK_GDB}"
 RDEPENDS_SDK_GDB = ""
 RDEPENDS_SDK_GDB:USE_sdk_gdb = "gdb"
 
 CLASS_FLAGS += "sdk_uboot_mkimage"
-DEFAULT_USE_sdk_uboot_mkimage = "1"
+DEFAULT_USE_sdk_uboot_mkimage = True
 RDEPENDS_SDK += "${RDEPENDS_SDK_UBOOT_MKIMAGE}"
 RDEPENDS_SDK_UBOOT_MKIMAGE = ""
 RDEPENDS_SDK_UBOOT_MKIMAGE:USE_sdk_uboot_mkimage = "${UBOOT_MKIMAGE}"

--- a/classes/sysvinit.oeclass
+++ b/classes/sysvinit.oeclass
@@ -7,7 +7,13 @@
 ## <chosen name> (declare this to RECIPE_FLAGS)
 ## SYSVINIT_SCRIPT_<chosen name> Set this to the name of your initscript.
 ## <chosen name>_sysvinit_start Set this to the start level.
-## <chosen name>_sysvinit_stop (optional) Set this to the stop level.
+## <chosen name>_sysvinit_stop Set this to the stop level.
+##
+## The level must be a two-digit string. To omit the start/stop
+## script, set <chosen name>_sysvinit_start / <chosen
+## name>_sysvinit_stop to False, e.g.
+##
+##   DEFAULT_USE_sshd_sysvinit_stop = False
 ##
 ## @useflag sysvinit Enable or disable sysvinit. Enabled by default by base
 ##          distro conf.
@@ -28,6 +34,7 @@ CLASS_FLAGS += "sysvinit"
 do_install[postfuncs] += "do_install_sysvinit"
 python do_install_sysvinit () {
     import os
+    import re
 
     path = d.get("D")
     os.chdir(path)
@@ -49,6 +56,17 @@ python do_install_sysvinit () {
         prio = d.get("USE_" + option)
         if not prio:
             continue
+        # "0" is the legacy way of disabling, and also what the token
+        # False currently translates to.
+        if prio == "0":
+            continue
+
+        # Anything but a two-digit string (or False, or "0") is a hard
+        # error.
+        if not re.match("[0-9][0-9]$", prio):
+            bb.error("Invalid value of 'USE_%s': %s" % (option, prio))
+            bb.error("Must be two-digit string or False")
+            return False
 
         if start_symlink:
             name = option[0:-len("_sysvinit_start")]

--- a/classes/sysvinit.oeclass
+++ b/classes/sysvinit.oeclass
@@ -31,15 +31,15 @@ RDEPENDS_${PN}:>USE_sysvinit = " ${RDEPENDS_SYSVINIT}"
 
 CLASS_FLAGS += "sysvinit"
 
-do_install[postfuncs] += "do_install_sysvinit"
+DO_INSTALL_SYSVINIT = ""
+DO_INSTALL_SYSVINIT:USE_sysvinit = "do_install_sysvinit"
+do_install[postfuncs] += "${DO_INSTALL_SYSVINIT}"
 python do_install_sysvinit () {
     import os
     import re
 
     path = d.get("D")
     os.chdir(path)
-    if not d.get("USE_sysvinit"):
-        return
 
     options = ((d.get("RECIPE_FLAGS") or "").split() +
                (d.get("CLASS_FLAGS") or "").split())

--- a/conf/distro/uclibc.conf
+++ b/conf/distro/uclibc.conf
@@ -6,5 +6,5 @@ def uclinux_arch_fixup(d):
     if d.get("MACHINE_CPU").startswith("m68k-mcf"):
         d.set("MACHINE_OS", "uclinux-uclibc")
 
-DISTRO_USE_busybox_ash = "0"
-DISTRO_USE_busybox_hush = "1"
+DISTRO_USE_busybox_ash = False
+DISTRO_USE_busybox_hush = True

--- a/conf/fstab.conf
+++ b/conf/fstab.conf
@@ -1,4 +1,4 @@
 fstabfixupdir = "${sysconfdir}/fstab.d"
 
 CLASS_FLAGS += "fstab"
-DEFAULT_USE_fstab = "1"
+DEFAULT_USE_fstab = True

--- a/conf/inittab.conf
+++ b/conf/inittab.conf
@@ -1,4 +1,4 @@
 inittabfixupdir = "${sysconfdir}/inittab.d"
 
 CLASS_FLAGS += "inittab"
-DEFAULT_USE_inittab = "1"
+DEFAULT_USE_inittab = True

--- a/conf/makedevs.conf
+++ b/conf/makedevs.conf
@@ -11,4 +11,4 @@ devtabledir		= "${sysconfdir}/devtable.d"
 MAKDEVS_FILES		?= ""
 
 CLASS_FLAGS += "makedevs"
-DEFAULT_USE_makedevs	= "1"
+DEFAULT_USE_makedevs	= True

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -664,7 +664,7 @@ class CookBook(Mapping):
                     return True
                 for name in flags.split():
                     val = meta.get("USE_"+name)
-                    if not val:
+                    if not val or val == "0":
                         debug("skipping %s:%s_%s (required %s USE flag not set)"%(
                                 recipe_type, meta.get("PN"), meta.get("PV"),
                                 name))

--- a/recipes/base-version/base-version.oe
+++ b/recipes/base-version/base-version.oe
@@ -35,7 +35,7 @@ OESTACK_VERSION[nohash] = "1"
 RECIPE_FLAGS += "basefiles_manifest_version"
 BASE_VERSION:USE_basefiles_manifest_version = "${OESTACK_VERSION}"
 
-DEFAULT_USE_basefiles_manifest_version = "1"
+DEFAULT_USE_basefiles_manifest_version = True
 
 RECIPE_FLAGS += "basefiles_version"
 BASE_VERSION_POSTFUNCS:>USE_basefiles_version = " do_install_basefiles_version"


### PR DESCRIPTION
These patches are all currently semantic noops, but they serve a few purposes: the prefunc/postfunc patches try to standardize on one idiom for running a pre/postfunc dependent on a use flag, and in doing so actually avoids running them if the use flag is not set (as opposed to doing an early return). Other patches change initializations of DEFAULT_USE_foo from using "0"/"1" to using False/True, which the lexer currently treats exactly equivalently (namely, storing the "0"/"1" string as the value), but they serve to document which USE flags are really meant as boolean flags, as opposed to those where the string value is actually used for something.

All patches are also preparation for potential future changes of the USE flag handling and the interpretation of the False/True tokens, but regardless of what thinks of such changes, I believe these patches are worthwhile in themselves.

Background (added 2016-11-17): USE flags are used and abused for different purposes, and their semantics in current OE-lite sometimes have some surprising consequences. Roughly, USE flags can be divided in two groups (but there may be some that fall outside of these categories, as well as some that straddle them): those that work entirely as boolean flags and are used as the conditionals in override assignments/appends/prepends (e.g. USE_sqlite3_readline), and those whose string value is used for some purpose (e.g. USE_rootfs_ext2_options). 

Now, in a given recipe which has foo in either RECIPE_FLAGS or CLASS_FLAGS, USE_foo gets its value from the first defined of RECIPE_USE_foo, LOCAL_USE_foo, MACHINE_USE_foo, DISTRO_USE_foo and finally DEFAULT_USE_foo. If none of these exist, the variable USE_foo also doesn't exist, and override assignments controlled by USE_foo do not get applied. The same happens if the value it would have is either the empty string or the string "0".

For boolean flags this is fine, and the behaviour is generally as expected from setting such USE flags to "1" or "0", since the values of boolean USE flags are never used directly, so their existence or non-existence by themselves is irrelevant.

HOWEVER, this means, for example, that it is not possible to set MACHINE_USE_rootfs_ext2_options = "", since this would cause a parse error when the (non-existing) variable USE_rootfs_ext2_options is expanded. Due to the way that particular variable is used, one could hack around this by assigning a string consisting of a few spaces, but that's obviously quite ugly, and similar workarounds may not always be applicable. Similar problems occur if one tries to set a configurable number and one just happens to wish it to have the value 0 (I'm looking at you, USE_busybox_feature_beep_length_ms).

This USE flag vanishing is rather confusing, and I aim to change it in some future meta/core release. For now, there is a lot we can do to make the world saner without changing any semantics, but which will prepare for such a change. It is a little known/used fact that the OE-lite language actually allows the tokens True and False on the right-hand side of an assignment. The lexer (currently) translates these to the strings "1" and "0", respectively. This means that we can change all initializations of boolean type USE flags (that is, the {DEFAULT,DISTRO,...}_USE_foo = "0"/"1") to use those tokens, which will help document what foo is (supposed to be) used for, without affecting semantics. Everybody is strongly encouraged to update their own recipes/distro/machine configs similarly.

Some string-type USE flags also need a sentinel value to mean "disable". An example of this is the USE_foo_sysvinit_stop, which historically has been set to "0" to omit the stop script being installed. In this case it is also advised to change to False (which, again, can be done without changing semantics) to highlight the difference between eliding the stop script ("0") vs. installing it at priority level "00".

The biggest problem with unconditionally defining USE variables to whatever value they have according to the RECIPE/LOCAL/... hierarchy comes from python code that does something like 'if d.get("USE_foo"): do something', since, in Python, the string "0" is true while None (the return value from get() when USE_foo doesn't exist) is False. I believe such python code is mostly concentrated in meta/core (we fix/prepare some of it in this series), and it should certainly be rare in random recipes found in the wild, but it is nevertheless such a large change that it should only happen with a couple of release's notice.
