### PR TITLE
oelite/meta/meta.py: ignore lineno flag in hash computation

### DIFF
--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -504,7 +504,7 @@ class MetaData(MutableMapping):
             return oelite.function.ShellFunction(self, name)
 
     @oelite.profiling.profile_calls
-    def signature(self, ignore_flags_re=re.compile("|".join(("__", "emit$", "filename"))),
+    def signature(self, ignore_flags_re=re.compile("|".join(("__", "emit$", "filename$", "lineno$"))),
                   force=False, dump=None):
         import hashlib
 


### PR DESCRIPTION
Currently, adding a single blank line at the top of core.oeclass or any
other file defining key python functions changes the metadata hash of
_everything_. Try to avoid that by ignoring changes in line numbers in
addition to ignoring the filename. While at it, make the match for
filename a little more stringent.