### PR TITLE
Introduce TOPLEVEL_VARS

### DIFF
--- a/classes/core.oeclass
+++ b/classes/core.oeclass
@@ -316,8 +316,6 @@ def core_varname_expansion(d):
                 d.set_flag(expanded_varname, flag, flags[flag])
             del d[varname]
 
-RELAXED[nohash] = True
-
 PRIORITY_MAX			= "90"
 PRIORITY_MIN			= "-9"
 RECIPE_PREFERENCE_PRIORITY	= "2"

--- a/classes/core.oeclass
+++ b/classes/core.oeclass
@@ -316,7 +316,6 @@ def core_varname_expansion(d):
                 d.set_flag(expanded_varname, flag, flags[flag])
             del d[varname]
 
-REBUILDALL_SKIP[nohash] = True
 RELAXED[nohash] = True
 
 PRIORITY_MAX			= "90"

--- a/conf/oe-lite.conf
+++ b/conf/oe-lite.conf
@@ -49,3 +49,7 @@ LD_LIBRARY_PATH_VAR = "LD_LIBRARY_PATH"
 LD_LIBRARY_PATH_VAR:BUILD_KERNEL_darwin = "DYLD_LIBRARY_PATH"
 
 BLACKLIST_VAR = "BLACKLIST_VAR BLACKLIST_PREFIX"
+
+# Variables which are only used by the initialization code and which
+# should not get inherited down to layer/recipe/task metadata.
+TOPLEVEL_VARS = "TOPLEVEL_VARS"

--- a/conf/oe-lite.conf
+++ b/conf/oe-lite.conf
@@ -53,3 +53,6 @@ BLACKLIST_VAR = "BLACKLIST_VAR BLACKLIST_PREFIX"
 # Variables which are only used by the initialization code and which
 # should not get inherited down to layer/recipe/task metadata.
 TOPLEVEL_VARS = "TOPLEVEL_VARS"
+TOPLEVEL_VARS += "PREBAKE_URL"
+TOPLEVEL_VARS += "PREBAKE_PATH"
+TOPLEVEL_VARS += "DEFAULT_RELAX"

--- a/conf/oe-lite.conf
+++ b/conf/oe-lite.conf
@@ -61,3 +61,6 @@ TOPLEVEL_VARS += "DEFAULT_RELAX"
 # incurring the time and memory cost of copying them.
 TOPLEVEL_VARS += "__oestack"
 TOPLEVEL_VARS += "__submodules"
+# Just used during cookbook initialization
+TOPLEVEL_VARS += "OERECIPES"
+TOPLEVEL_VARS += "OERECIPES_PRETTY"

--- a/conf/oe-lite.conf
+++ b/conf/oe-lite.conf
@@ -56,3 +56,8 @@ TOPLEVEL_VARS = "TOPLEVEL_VARS"
 TOPLEVEL_VARS += "PREBAKE_URL"
 TOPLEVEL_VARS += "PREBAKE_PATH"
 TOPLEVEL_VARS += "DEFAULT_RELAX"
+# __oestack and __submodules are defined in oebakery, but not used by
+# any commands implemented in meta/core. Get rid of them to avoid
+# incurring the time and memory cost of copying them.
+TOPLEVEL_VARS += "__oestack"
+TOPLEVEL_VARS += "__submodules"

--- a/conf/oe-lite.conf
+++ b/conf/oe-lite.conf
@@ -35,7 +35,6 @@ include conf/provided/${PROVIDED}.conf
 include conf/documentation.conf
 
 OE_DEFAULT_TASK ?= "build"
-OE_DEFAULT_TASK[nohash] = "1"
 
 DEFAULT_RELAX[nohash] = "1"
 PREBAKE_PATH[nohash] = "1"
@@ -64,3 +63,4 @@ TOPLEVEL_VARS += "__submodules"
 # Just used during cookbook initialization
 TOPLEVEL_VARS += "OERECIPES"
 TOPLEVEL_VARS += "OERECIPES_PRETTY"
+TOPLEVEL_VARS += "OE_DEFAULT_TASK"

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -90,9 +90,12 @@ class CookBook(Mapping):
         def layer_height_roundup(priority):
             return (priority+99)/100*100
         layer_conf_files = []
+        toplevel_vars = (self.config.get("TOPLEVEL_VARS") or "").split()
         for layer in reversed(oepath):
             layer_conf = os.path.join(layer, 'conf', 'layer.conf')
             layer_meta = self.config.copy()
+            for v in toplevel_vars:
+                layer_meta.del_var(v)
             if os.path.exists(layer_conf):
                 self.oeparser.set_metadata(layer_meta)
                 self.oeparser.reset_lexstate()

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -395,6 +395,7 @@ class MetaData(MutableMapping):
         "COMPATIBLE_IF_FLAGS",
         "_task_deps",
         "REBUILDALL_SKIP",
+        "RELAXED",
     ])
 
     builtin_nohash_prefix = [

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -394,6 +394,7 @@ class MetaData(MutableMapping):
         "INCOMPATIBLE_RECIPES",
         "COMPATIBLE_IF_FLAGS",
         "_task_deps",
+        "REBUILDALL_SKIP",
     ])
 
     builtin_nohash_prefix = [

--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -381,8 +381,6 @@ class MetaData(MutableMapping):
         "TMPDIR",
         "OEPATH",
         "OEPATH_PRETTY",
-        "OERECIPES",
-        "OERECIPES_PRETTY",
         "FILE",
         "COMPATIBLE_BUILD_ARCHS",
         "COMPATIBLE_HOST_ARCHS",


### PR DESCRIPTION
This is like BLACKLIST, but a few levels higher in the hierarchy. There are some variables we might as well get rid of before spending time and memory copying them down to layer, recipe and task metadata, only to then spend more time deciding not to hash them.

I'm also going to introduce some variables controlling profiling (to be set in local.conf), and these are also obvious TOPLEVEL stuff.