### PR TITLE
lib/oelite/meta/meta.py: remove OE_{REMOTE,MODULE} handling

### DIFF
--- a/lib/oelite/meta/meta.py
+++ b/lib/oelite/meta/meta.py
@@ -370,8 +370,6 @@ class MetaData(MutableMapping):
 
 
     builtin_nohash = frozenset([
-        "OE_REMOTES",
-        "OE_MODULES",
         "OE_ENV_WHITELIST",
         "PATH",
         "PWD",
@@ -395,11 +393,6 @@ class MetaData(MutableMapping):
         "COMPATIBLE_IF_FLAGS",
         "_task_deps",
     ])
-
-    builtin_nohash_prefix = [
-        "OE_REMOTE_",
-        "OE_MODULE_",
-    ]
 
     def dump_var(self, key, o=sys.__stdout__, pretty=True, dynvars=[],
                  flags=False, ignore_flags_re=None):
@@ -484,13 +477,6 @@ class MetaData(MutableMapping):
                 if key in self.builtin_nohash:
                     continue
                 if self.get_flag(key, "nohash"):
-                    continue
-                nohash_prefixed = False
-                for prefix in self.builtin_nohash_prefix:
-                    if key.startswith(prefix):
-                        nohash_prefixed = True
-                        break
-                if nohash_prefixed:
                     continue
             self.dump_var(key, o, pretty, dynvars, flags, ignore_flags_re)
 


### PR DESCRIPTION
No variables called OE_REMOTES, OE_MODULES, OE_REMOTE_* or OE_MODULE_*
have existed since bakery commit 74d7bd345 (which has been in OE bakery
since at least 3.0.0). Getting rid of those means we can remove the
nohash_prefix handling, which in turn saves several million .startswith
calls during hash computation.