### PR TITLE
optimize libmagic use

### DIFF
--- a/classes/chrpath.oeclass
+++ b/classes/chrpath.oeclass
@@ -38,10 +38,9 @@ CHRPATH_REPLACE_STAGEDIRS:sdk-cross	= "1"
 do_chrpath[dirs] = "${D}"
 def do_chrpath(d):
     import stat
-    import magic
+    import oelite.magiccache
 
-    filemagic = magic.open(magic.MAGIC_NONE)
-    filemagic.load()
+    filemagic = oelite.magiccache.open()
 
     replace_stagedirs = d.get("CHRPATH_REPLACE_STAGEDIRS")
     stage_dir = d.get('STAGE_DIR')
@@ -139,6 +138,7 @@ def do_chrpath(d):
         if not rc:
             return rc
 
+    filemagic.close()
     return
 
 # Local Variables:

--- a/classes/core.oeclass
+++ b/classes/core.oeclass
@@ -138,13 +138,12 @@ def runstrip(file, d):
     # A working 'file' (one which works on the target architecture)
     # is necessary for this stuff to work, hence the addition to do_package[depends]
 
-    import commands, stat, re, magic
+    import commands, stat, re, oelite.magiccache
 
     pathprefix = "export PATH=%s; " % bb.data.getVar('PATH', d, True)
     print "pathprefix =",pathprefix
 
-    filemagic = magic.open(magic.MAGIC_NONE)
-    filemagic.load()
+    filemagic = oelite.magiccache.open()
     filetype = filemagic.file(file)
     filemagic.close()
 

--- a/classes/elfwrapper.oeclass
+++ b/classes/elfwrapper.oeclass
@@ -21,10 +21,9 @@ IMAGE_PREPROCESS_ELF_SOWRAP = ""
 IMAGE_PREPROCESS_ELF_SOWRAP:HOST_BINFMT_elf = " image_preprocess_elf_sowrap"
 def image_preprocess_elf_sowrap(d):
     import stat
-    import magic
+    import oelite.magiccache
 
-    filemagic = magic.open(magic.MAGIC_NONE)
-    filemagic.load()
+    filemagic = oelite.magiccache.open()
     host_elf_re = re.compile(d.get("HOST_ELF"))
     command_re = re.compile(" executable, ")
     static_re = re.compile("statically")

--- a/classes/image-qa.oeclass
+++ b/classes/image-qa.oeclass
@@ -52,13 +52,13 @@ IMAGEQA_TARGET_READELF_LIB_DIRS ?= "\
 "
 
 python do_imageqa () {
-    import os, magic, re
+    import os, re
+    import oelite.magiccache
     from subprocess import Popen, PIPE
     from glob import glob
     import oebakery # die, err, warn, info, debug
     os.environ['PATH'] = d.getVar("PATH", True)
-    filemagic = magic.open(magic.MAGIC_NONE)
-    filemagic.load()
+    filemagic = oelite.magiccache.open()
 
     def readelf_check(arch):
         readelf = d.getVar("IMAGEQA_"+arch+"_READELF", True)

--- a/classes/package-qa.oeclass
+++ b/classes/package-qa.oeclass
@@ -221,7 +221,8 @@ PACKAGEQA_BUILD_LIBDIRS ?= "\
 "
 
 def do_packageqa(d):
-    import os, magic, re
+    import os, re
+    import oelite.magiccache
     from subprocess import Popen, PIPE
     from glob import glob
     import oebakery # die, err, warn, info, debug
@@ -230,8 +231,7 @@ def do_packageqa(d):
         pass
 
     os.environ['PATH'] = d.getVar("PATH", True)
-    filemagic = magic.open(magic.MAGIC_NONE)
-    filemagic.load()
+    filemagic = oelite.magiccache.open()
 
     pn = d.get("PN")
     def pkg_with_pn(pkg):
@@ -800,6 +800,7 @@ def do_packageqa(d):
             print 'DEPENDS_%s += "%s"'%(pkg_with_pn(pkg), depends)
         print "-"*42
 
+    filemagic.close()
     return ok
 
 addtask packageqaall after packageqa

--- a/lib/oelite/magiccache.py
+++ b/lib/oelite/magiccache.py
@@ -1,0 +1,41 @@
+import magic
+
+class OEliteMagic:
+
+    def __init__(self, flags, filename):
+        self.refs = 1
+        self.magic  = magic.open(flags)
+        self.filename = filename
+        self.magic.load(self.filename)
+
+    def get(self):
+        self.refs += 1
+        return self
+
+    def file(self, filename):
+        return self.magic.file(filename)
+
+    def descriptor(self, fd):
+        return self.magic.descriptor(fd)
+
+    def close(self):
+        self.refs -= 1
+        if self.refs == 0:
+            self.magic.close()
+            self.magic = None
+
+
+cache = dict()
+
+def open(flags = magic.MAGIC_NONE, filename=None):
+    t = (flags,filename)
+    if t not in cache:
+        cache[t] = OEliteMagic(flags, filename)
+    return cache[t].get()
+
+# Drop the reference held by the cache dict - existing instances
+# continue to be valid.
+def clear_cache():
+    for f in cache.keys():
+        cache[f].close()
+        del cache[f]

--- a/lib/oelite/magiccache.py
+++ b/lib/oelite/magiccache.py
@@ -39,3 +39,8 @@ def clear_cache():
     for f in cache.keys():
         cache[f].close()
         del cache[f]
+
+# Pre-cache the handle everybody in practice wants to use. Otherwise,
+# when we run python tasks in their own processes, they won't benefit
+# from this cache.
+open().close()


### PR DESCRIPTION
runstrip opens, parses and closes the system's "magic" database for every file it processes, which is somewhat wasteful.

Each do_chrpath leaks the open database handle, which amounts to 700MB+ of extra VM during oe bake world.

Since we only ever use the default database with default flags, just open and parse the database once.
 