### PR TITLE
oelite/parse: fix "statement not allowed" error reporting

### DIFF
--- a/lib/oelite/parse/__init__.py
+++ b/lib/oelite/parse/__init__.py
@@ -131,10 +131,9 @@ class ParseError(Exception):
                 print self.more_details
         return
 
+class StatementNotAllowedInConf(ParseError):
 
-class StatementNotAllowed(ParseError):
-
-    def __init(self, parser, p, statement):
+    def __init__(self, parser, p, statement):
         super(StatementNotAllowedInConf, self).__init__(
             parser, "%s statement not allowed"%(statement), p)
         return
@@ -151,7 +150,7 @@ class FileNotFound(ParseError):
 
 __all__ = [
     "oelex", "oeparse", "confparse",
-    "ParseError", "StatementNotAllowed", "FileNotFound",
+    "ParseError", "StatementNotAllowedInConf", "FileNotFound",
     "oelexer",
     ]
 

--- a/lib/oelite/parse/confparse.py
+++ b/lib/oelite/parse/confparse.py
@@ -1,8 +1,10 @@
 import oelite.parse
 from oelite.parse.oeparse import OEParser
+from oelite.parse import StatementNotAllowedInConf
 
 import ply.lex
 import ply.yacc
+
 
 class ConfParser(OEParser):
 
@@ -15,18 +17,18 @@ class ConfParser(OEParser):
 
     def p_inherit(self, p):
         '''inherit : INHERIT inherit_classes'''
-        raise StatementNotAllowed(self, p, "inherit")
+        raise StatementNotAllowedInConf(self, p, "inherit")
 
 
     # Override addtask statements
 
     def p_addtask(self, p):
         '''addtask : addtask_task'''
-        raise StatementNotAllowed(self, p, "addtask")
+        raise StatementNotAllowedInConf(self, p, "addtask")
 
     def p_addtask_w_dependencies(self, p):
         '''addtask : addtask_task addtask_dependencies'''
-        raise StatementNotAllowed(self, p, "addtask")
+        raise StatementNotAllowedInConf(self, p, "addtask")
 
 
     # Override function definitions
@@ -34,12 +36,12 @@ class ConfParser(OEParser):
     #def p_def_func(self, p):
     #    '''def_func : DEF VARNAME def_funcargs NEWLINE func_body
     #                | DEF VARNAME def_funcargs NEWLINE func_body FUNCSTOP'''
-    #    raise StatementNotAllowed(self, p, "def function")
+    #    raise StatementNotAllowedInConf(self, p, "def function")
     #
     #def p_func(self, p):
     #    '''func : VARNAME FUNCSTART func_body FUNCSTOP'''
-    #    raise StatementNotAllowed(self, p, "function")
+    #    raise StatementNotAllowedInConf(self, p, "function")
 
     def p_python_anonfunc(self, p):
         '''python_func : PYTHON FUNCSTART func_body FUNCSTOP'''
-        raise StatementNotAllowed(self, p, "anonymous function")
+        raise StatementNotAllowedInConf(self, p, "anonymous function")


### PR DESCRIPTION
The attempt to provide a helpful error message for addhook and other
statements in .conf files fails for a number of reasons. First, the
exception class is not imported into confparse.py, second, the super
statement calls it "StatementNotAllowedInConf" while the class is just
"StatementNotAllowed", and third, the __init__ def lacks the two
trailing underscores, so the ParseError __init__ is anyway called
directly, causing an assert error (after fixing the first two bugs)
since the p argument ends up being passed as the message
parameter.

Since this is only used in confparse.py, I tried moving the exception
class definition to confparse.py, but ran into some cyclic import
issue, so I left it in __init__.py, but still chose the longer name.

Add e.g. "addtask foo" to local.conf to test this. Before:

ERROR: exception in bake.run()

Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/oebakery/cmd/cmds.py", line 137, in call
    ret = function(*args)
[snip snip...]
  File "/usr/lib/python2.7/dist-packages/ply/yacc.py", line 975, in parseopt_notrack
    p.callable(pslice)
  File "/mnt/xfs/devel/oe-lite/meta/core/lib/oelite/parse/confparse.py", line 25, in p_addtask
    raise StatementNotAllowed(self, p, "addtask")
NameError: global name 'StatementNotAllowed' is not defined

CRITICAL: bake failed: Exception: global name 'StatementNotAllowed' is not defined

After:

Parse error
addtask statement not allowed in /mnt/xfs/devel/oe-lite/conf/local.conf at line 17
   12 __ASYNC_STAGE = True
   13 __ASYNC_CHRPATH = True
   14 __ASYNC_SPLIT = True
   15 __ASYNC_PACKAGE = True
   16
-> 17 addtask foo
Included from /mnt/xfs/devel/oe-lite/meta/core/conf/oe-lite.conf

CRITICAL: bake failed: Parse error