### PR TITLE
allow depending on multiple versions

### DIFF
--- a/classes/stage.oeclass
+++ b/classes/stage.oeclass
@@ -91,7 +91,8 @@ def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir,
         oelite.util.makedirs(dstdir)
 
         pkgmetadir = d.get("pkgmetadir").lstrip("/")
-        dst_pkgmetadir = os.path.join(dstdir, pkgmetadir, package.name)
+        pkgname_ver = package.name + "_" + package.version
+        dst_pkgmetadir = os.path.join(dstdir, pkgmetadir, pkgname_ver)
         if os.path.exists(pkgmetadir):
             os.renames(pkgmetadir, dst_pkgmetadir)
 
@@ -124,7 +125,7 @@ def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir,
                 if os.path.exists(dstfile):
                     file_priorities = {}
                     update_file_priority(file_priorities, srcfile,
-                                         package.name, dstdir)
+                                         pkgname_ver, dstdir)
 
                     for (pkgtarfn, pkgname, pkgdstdir) in staged_packages:
                         if pkgdstdir != dstdir:
@@ -148,9 +149,9 @@ def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir,
                         conflicts = True
                         continue
                     bb.debug("priority overwrite of stage file: /%s"%(srcfile))
-                    if file_priorities[priority][0] != package.name:
+                    if file_priorities[priority][0] != pkgname_ver:
                         continue
-                    print "overwriting with %s from %s"%(srcfile, package.name)
+                    print "overwriting with %s from %s"%(srcfile, pkgname_ver)
 
                 # FIXME: check if owner/group/perms match
                 os.renames(srcfile, dstfile)
@@ -160,7 +161,7 @@ def set_stage(d, stage, stage_fixup_funcs, get_dstdir, unpackdir,
         os.chdir(dstdir)
         shutil.rmtree(unpackdir)
 
-        staged_packages.append((filename, package.name, dstdir))
+        staged_packages.append((filename, pkgname_ver, dstdir))
 
 STAGE_FIXUP_FUNCS ?= ""
 

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -705,15 +705,12 @@ class CookBook(Mapping):
                 taskseq)
 
         for deptype in ("DEPENDS", "RDEPENDS", "FDEPENDS"):
-            recipe_depends = []
             for item in (recipe.meta.get(deptype) or "").split():
                 item = oelite.item.OEliteItem(item, (deptype, recipe.type))
-                recipe_depends.append((deptype, item))
+                recipe.item_deps[deptype].add(item)
             for item in (recipe.meta.get("CLASS_"+deptype) or "").split():
                 item = oelite.item.OEliteItem(item, (deptype, recipe.type))
-                recipe_depends.append((deptype, item))
-            for (deptype, item) in recipe_depends:
-                recipe.item_deps[deptype][(item.type, item.name)] = item.version
+                recipe.item_deps[deptype].add(item)
 
         for task_name in task_names:
             task_id = flatten_single_value(self.dbc.execute(

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -169,15 +169,6 @@ class CookBook(Mapping):
             "UNIQUE (recipe, name) ON CONFLICT IGNORE ) ")
 
         self.dbc.execute(
-            "CREATE TABLE IF NOT EXISTS recipe_depend ( "
-            "recipe      INTEGER, "
-            "deptype     TEXT, "
-            "type        TEXT, "
-            "item        TEXT, "
-            "version     TEXT, "
-            "UNIQUE (recipe, deptype, type, item) ON CONFLICT REPLACE )")
-
-        self.dbc.execute(
             "CREATE TABLE IF NOT EXISTS provide ( "
             "package     INTEGER, "
             "item        TEXT, "
@@ -721,10 +712,6 @@ class CookBook(Mapping):
             for item in (recipe.meta.get("CLASS_"+deptype) or "").split():
                 item = oelite.item.OEliteItem(item, (deptype, recipe.type))
                 recipe_depends.append((recipe_id, deptype, item.type, item.name, item.version))
-            if recipe_depends:
-                self.dbc.executemany(
-                    "INSERT INTO recipe_depend (recipe, deptype, type, item, version) "
-                    "VALUES (?, ?, ?, ?, ?)", recipe_depends)
             for d in recipe_depends:
                 recipe.item_deps[d[1]][(d[2], d[3])] = d[4]
 

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -725,6 +725,8 @@ class CookBook(Mapping):
                 self.dbc.executemany(
                     "INSERT INTO recipe_depend (recipe, deptype, type, item, version) "
                     "VALUES (?, ?, ?, ?, ?)", recipe_depends)
+            for d in recipe_depends:
+                recipe.item_deps[d[1]][(d[2], d[3])] = d[4]
 
         for task_name in task_names:
             task_id = flatten_single_value(self.dbc.execute(

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -708,12 +708,12 @@ class CookBook(Mapping):
             recipe_depends = []
             for item in (recipe.meta.get(deptype) or "").split():
                 item = oelite.item.OEliteItem(item, (deptype, recipe.type))
-                recipe_depends.append((recipe_id, deptype, item.type, item.name, item.version))
+                recipe_depends.append((deptype, item))
             for item in (recipe.meta.get("CLASS_"+deptype) or "").split():
                 item = oelite.item.OEliteItem(item, (deptype, recipe.type))
-                recipe_depends.append((recipe_id, deptype, item.type, item.name, item.version))
-            for d in recipe_depends:
-                recipe.item_deps[d[1]][(d[2], d[3])] = d[4]
+                recipe_depends.append((deptype, item))
+            for (deptype, item) in recipe_depends:
+                recipe.item_deps[deptype][(item.type, item.name)] = item.version
 
         for task_name in task_names:
             task_id = flatten_single_value(self.dbc.execute(

--- a/lib/oelite/item.py
+++ b/lib/oelite/item.py
@@ -36,10 +36,13 @@ class OEliteItem:
         return string
 
     def __eq__(self, other):
-        return (self.type == other.type and
-                self.item == other.item and
-                self.version == other.version)
+        return (self.as_tuple() == other.as_tuple())
 
+    def as_tuple(self):
+        return (self.type, self.name, self.version)
+
+    def __hash__(self):
+        return hash(self.as_tuple())
 
 TYPEMAP = {
 

--- a/lib/oelite/recipe.py
+++ b/lib/oelite/recipe.py
@@ -43,7 +43,7 @@ class OEliteRecipe:
         self.item_deps = {}
         for deptype in ("DEPENDS", "RDEPENDS", "FDEPENDS"):
             # (type, itemname) => version
-            self.item_deps[deptype] = {}
+            self.item_deps[deptype] = set()
         return
 
 
@@ -74,11 +74,8 @@ class OEliteRecipe:
         if not deptypes:
             deptypes = self.item_deps.keys()
         for t in deptypes:
-            for ((type, item), version) in self.item_deps[t].items():
-                if version is None:
-                    depends.append("%s:%s" % (type, item))
-                else:
-                    depends.append("%s:%s_%s" % (type, item, version))
+            for item in self.item_deps[t]:
+                depends.append(str(item))
         return depends
 
 

--- a/lib/oelite/recipe.py
+++ b/lib/oelite/recipe.py
@@ -71,29 +71,14 @@ class OEliteRecipe:
 
     def get_depends(self, deptypes=[]):
         depends = []
-        depends2 = []
-        if deptypes:
-            deptypes_in = " AND deptype IN (%s)"%(
-                ",".join("?" for i in deptypes))
-        else:
-            deptypes_in = ""
-        for type, item, version in self.cookbook.dbc.execute(
-            "SELECT type, item, version FROM recipe_depend "
-            "WHERE recipe_depend.recipe=?%s"%(deptypes_in),
-            ([self.id] + deptypes)):
-            if version is None:
-                depends.append("%s:%s"%(type, item))
-            else:
-                depends.append("%s:%s_%s"%(type, item, version))
         if not deptypes:
             deptypes = self.item_deps.keys()
         for t in deptypes:
             for ((type, item), version) in self.item_deps[t].items():
                 if version is None:
-                    depends2.append("%s:%s" % (type, item))
+                    depends.append("%s:%s" % (type, item))
                 else:
-                    depends2.append("%s:%s_%s" % (type, item, version))
-        assert(sorted(depends) == sorted(depends2))
+                    depends.append("%s:%s_%s" % (type, item, version))
         return depends
 
 

--- a/lib/oelite/recipe.py
+++ b/lib/oelite/recipe.py
@@ -40,6 +40,10 @@ class OEliteRecipe:
         self._hash = None
         self.recipe_deps = set([])
         self.tasks = set([])
+        self.item_deps = {}
+        for deptype in ("DEPENDS", "RDEPENDS", "FDEPENDS"):
+            # (type, itemname) => version
+            self.item_deps[deptype] = {}
         return
 
 
@@ -67,6 +71,7 @@ class OEliteRecipe:
 
     def get_depends(self, deptypes=[]):
         depends = []
+        depends2 = []
         if deptypes:
             deptypes_in = " AND deptype IN (%s)"%(
                 ",".join("?" for i in deptypes))
@@ -80,6 +85,15 @@ class OEliteRecipe:
                 depends.append("%s:%s"%(type, item))
             else:
                 depends.append("%s:%s_%s"%(type, item, version))
+        if not deptypes:
+            deptypes = self.item_deps.keys()
+        for t in deptypes:
+            for ((type, item), version) in self.item_deps[t].items():
+                if version is None:
+                    depends2.append("%s:%s" % (type, item))
+                else:
+                    depends2.append("%s:%s_%s" % (type, item, version))
+        assert(sorted(depends) == sorted(depends2))
         return depends
 
 


### PR DESCRIPTION
When I did PR#207, I wasn't aware that current OE-lite silently throws away all but the last encountered dependency for a specific item. While explicitly depending on two or more different versions of the same item may be rare, there are certainly use cases, and having the final dependencies depend on the order they appear in DEPENDS / CLASS_DEPENDS is somewhat fragile.

With this, one can do DEPENDS = "bar_3 bar_4" and have both bar_3 and bar_4 staged; if there are file conflicts, do_stage will complain as usual.