### PR TITLE
binutils: make sure binutils-libiberty provides libiberty

### DIFF
--- a/recipes/binutils/binutils.inc
+++ b/recipes/binutils/binutils.inc
@@ -64,6 +64,7 @@ PACKAGEQA_HOST_LIBDIRS += "/${HOST_ARCH}/${TARGET_ARCH}/lib"
 PACKAGES =+ "${PN}-libiberty ${PN}-libiberty-dev"
 FILES_${PN}-libiberty = "${libdir}/libiberty.a"
 FILES_${PN}-libiberty-dev = "${includedir}/libiberty.h"
+PROVIDES_${PN}-libiberty += "libiberty"
 
 FILES_${PN}-libopcodes-dev = "${AUTO_PACKAGE_LIBS_LIBDIR_PREFIX}${includedir}/dis-asm.h"
 FILES_${PN}-libbfd-dev = "${AUTO_PACKAGE_LIBS_LIBDIR_PREFIX}${includedir}/"


### PR DESCRIPTION
When building packages manually, one should also set appropriate
PROVIDES_*. Otherwise other recipes start depending on the package
name (binutils-libiberty) rather than the item they really
need (libiberty), needlessly making them dependent on how binutils is
split up.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>