### PR TITLE
lib/oelite: try to avoid subtle SIGPIPE related errors in subprocesses

### DIFF
--- a/lib/oelite/function.py
+++ b/lib/oelite/function.py
@@ -8,6 +8,7 @@ import shutil
 import warnings
 import re
 import subprocess
+import oelite.signal
 
 class OEliteFunction(object):
 
@@ -157,7 +158,8 @@ class ShellFunction(OEliteFunction):
         print '> %s'%(cmd,)
 
         try:
-            self.subprocess = subprocess.Popen(cmd, stdin=sys.stdin, shell=True)
+            self.subprocess = subprocess.Popen(cmd, stdin=sys.stdin, shell=True,
+                                               preexec_fn = oelite.signal.restore_defaults)
         except OSError, e:
             if e.errno == 2:
                 print "Error: Command not found:", cmdname

--- a/lib/oelite/signal.py
+++ b/lib/oelite/signal.py
@@ -1,0 +1,32 @@
+# Low-level signal handling stuff that we unfortunately may need to
+# worry about.
+
+from __future__ import absolute_import
+
+import signal
+
+# The Python runtime sets the signal disposition for SIGPIPE to
+# SIG_IGN. Unfortunately, such a setting is preserved across both
+# fork() and execve(), so unless a spawned program itself takes steps
+# to set it back to SIG_DFL (and I know that bash does not), this will
+# affect the entire subprocess tree. There may be programs which
+# (probably unknowingly) rely on SIGPIPE resulting in the default
+# action of terminating the process.  There are certainly no programs
+# that expect to started with SIG_IGN for SIGPIPE - if they want to
+# get -EPIPE instead of the signal, they do the signal(2) call
+# themselves. I haven't seen any problems that can directly be
+# attributed to this, but that doesn't mean there haven't been any,
+# since errors like these would presumably be extremely hard to
+# debug. In any case, this is the right thing to do. This is usable as
+# a preexec_fn in a subprocess.Popen() call.
+#
+# initsigs() in CPython also munges with SIGXFZ and SIGXFSZ, so handle
+# them as well - essentially, the below is a Python2 port of Python3's
+# _Py_RestoreSignals.
+def restore_defaults():
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    if hasattr(signal, "SIGXFZ"):
+        signal.signal(signal.SIGXFZ, signal.SIG_DFL)
+    if hasattr(signal, "SIGXFSZ"):
+        signal.signal(signal.SIGXFSZ, signal.SIG_DFL)


### PR DESCRIPTION
Python, in order to be able to throw an OSError(EPIPE) exception rather
than terminating directly upon writing to a closed pipe, sets the signal
disposition for SIGPIPE to SIG_IGN. Unfortunately, POSIX specifies under
exec*() that "Except for SIGCHLD, signals set to be ignored (SIG_IGN) by
the calling process image shall be set to be ignored by the new process
image.". This means that, unless some program itself takes an explicit
step to restore the default disposition for SIGPIPE, the entire
subprocess tree will receive -EPIPE upon writing to a closed pipe rather
than being terminated automatically. If some program down the tree,
knowingly or not, relies on the usual behaviour, this can lead to
hard-to-debug errors (or worse, http://bugs.python.org/issue1652).

This is fixed in Python 3.2+, at least for the subprocess module, but we
have to do it ourselves. This just changes the two most important users,
oelite.util.shcmd() and oelite.function.ShellFunction (the latter being
the one that handles all task, pre- and postfunctions which are
implemented as bash scripts, which is where the deepest subprocess trees
are created).