### PR TITLE
oelite/fetch/url.py: fix permissions of generated files

### DIFF
--- a/lib/oelite/fetch/url.py
+++ b/lib/oelite/fetch/url.py
@@ -127,6 +127,12 @@ def grab(url, filename, timeout=120, retry=5, proxies=None, passive_ftp=True):
     # actual ingredient dir rather than e.g. /tmp to ensure that we
     # can do a link(2) call without encountering EXDEV.
     (fd, dl_tgt) = tempfile.mkstemp(prefix = f + ".", dir = d)
+    # Unfortunately, mkstemp() uses mode 0o600 when opening the file,
+    # but we'd rather have used 0o644. So we get to do a little syscall
+    # dance, yay.
+    mask = os.umask(0o022)
+    os.fchmod(fd, 0o644 & ~mask)
+    os.umask(mask)
 
     cmd = ['wget', '-t', str(retry), '-T', str(timeout), psvftp, '--no-check-certificate', '--progress=dot:mega', '-v', url, '-O', '-']
 


### PR DESCRIPTION
Downloaded files used to be created with mode 0o644 (modified by umask
as usual), but since we now let tempfile.mkstemp do the open(O_CREAT),
we get 0o600. This is a problem at least for mirroring where oe-lite
runs as one user but the webserver runs as another. The simplest way to
fix it up seems to be an explicit fchmod.