### PR TITLE
Fix gcc sysroot .la files

### DIFF
--- a/classes/libtool.oeclass
+++ b/classes/libtool.oeclass
@@ -114,6 +114,7 @@ def do_install_libtool_lafile_fixup(d):
         with open(filename, "r") as input_file:
             lafile = input_file.read()
         for strip_dir in strip_dirs:
+            strip_dir = re.escape(strip_dir)
             lafile = re.sub("-L%s"%(strip_dir),
                              "-L", lafile)
             lafile = re.sub("([' ])%s"%(strip_dir),

--- a/recipes/gcc/gcc-common.inc
+++ b/recipes/gcc/gcc-common.inc
@@ -252,6 +252,11 @@ do_install() {
 		[ -e "$libdir" ] || continue
 		mkdir -p $target_libdir_parent
 		mv $libdir $target_libdir_parent/`basename $libdir`
+		# Fix .la files; replace old path with new
+		for lafile in $target_libdir_parent/`basename $libdir`/*.la ; do
+			[ -f "$lafile" ] || continue
+			sed -i -e "s:$libdir:$target_libdir_parent/`basename $libdir`:g" "$lafile"
+		done
 	done
 	for d in "${D}/share/gcc-${PV}/python/"* ; do
 		[ -e "$d" ] || continue

--- a/recipes/gcc/gcc.inc
+++ b/recipes/gcc/gcc.inc
@@ -36,6 +36,7 @@ inherit libtool
 LIBTOOL_DEPENDS = ""
 LIBTOOL_FIXUP_SEARCH_DIRS_CROSS += "${D}${libexecdir}/gcc/${TARGET_ARCH}/${PV}"
 LIBTOOL_FIXUP_STRIP_DIRS += "${HOST_SYSROOT} ${STAGE_DIR}/${TARGET_CROSS}"
+LIBTOOL_FIXUP_STRIP_DIRS =+ "${D_SYSROOT}"
 do_compile_targets:canadian-cross = "all-gcc"
 
 do_install_targets:canadian-cross = "install-gcc"


### PR DESCRIPTION
Resolves errors like:
  /bin/sh ../libtool --tag=CXX --mode=link
  /bin/grep: work/machine/aarch64-cortexa53t-linux-gnu/some/stage/machine/lib/libstdc++.la: No such file or directory
  /bin/sed: can't read work/machine/aarch64-cortexa53t-linux-gnu/some/stage/machine/lib/libstdc++.la: No such file or directory
  libtool: error: 'work/machine/aarch64-cortexa53t-linux-gnu/some/stage/machine/lib/libstdc++.la' is not a valid libtool archive

In gcc install we move the sysroot libraries from:
  work/cross/aarch64-cortexa53t-linux-gnu/gcc-6.3.0/install/aarch64-cortexa53t-linux-gnu/lib

To:
  work/cross/aarch64-cortexa53t-linux-gnu/gcc-6.3.0/install/aarch64-cortexa53t-linux-gnu/sysroot/usr/lib

We do not update the .la files containing fx.:
  # Directory that this library needs to be installed in:
  libdir='/tmp/work/cross/aarch64-cortexa53t-linux-gnu/gcc-6.3.0/install/aarch64-cortexa53t-linux-gnu/lib'

do_install_libtool_lafile_fixup() ensures that the first part is removed
leaving:
  libdir='/aarch64-cortexa53t-linux-gnu/lib'

That is not something we can understand when staging the package and
running libtool_stage_fixup().

This patch ensures the la file is updated with the new location we move
the lib to:
  libdir='/tmp/work/cross/aarch64-cortexa53t-linux-gnu/gcc-6.3.0/install/aarch64-cortexa53t-linux-gnu/sysroot/usr/lib'

And sets LIBTOOL_FIXUP_STRIP_DIRS to that sysroot path resulting in a .la file with the expected contents:
  libdir='/usr/lib'