### PR TITLE
add "oe test" subcommand

### DIFF
--- a/lib/oelite/cmd/__init__.py
+++ b/lib/oelite/cmd/__init__.py
@@ -1,1 +1,1 @@
-manifest_cmds = [ "bake", "setup", "show", "cherry", "autodoc", "add-layer" ]
+manifest_cmds = [ "bake", "setup", "show", "cherry", "autodoc", "add-layer", "test" ]

--- a/lib/oelite/cmd/test.py
+++ b/lib/oelite/cmd/test.py
@@ -1,0 +1,91 @@
+import errno
+import os
+import select
+import shutil
+import signal
+import sys
+import tempfile
+import time
+import unittest
+
+import oelite.util
+
+description = "Run tests of internal utility functions"
+def add_parser_options(parser):
+    parser.add_option("-s", "--show",
+                      action="store_true", default=False,
+                      help="Show list of tests")
+
+class OEliteTest(unittest.TestCase):
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+        os.chdir(self.wd)
+
+    def tearDown(self):
+        os.chdir("/")
+        shutil.rmtree(self.wd)
+
+class MakedirsRaceTest(OEliteTest):
+    def child(self):
+        signal.alarm(2) # just in case of infinite recursion bugs
+        try:
+            # wait for go
+            select.select([self.r], [], [], 1)
+            oelite.util.makedirs(self.path)
+            # no exception? all right
+            res = "OK"
+        except OSError as e:
+            # errno.errorcode(errno.ENOENT) == "ENOENT" etc.
+            res = errno.errorcode.get(e.errno) or str(e.errno)
+        except Exception as e:
+            res = "??"
+        finally:
+            # Short pipe writes are guaranteed atomic
+            os.write(self.w, res+"\n")
+            os._exit(0)
+
+    def setUp(self):
+        super(MakedirsRaceTest, self).setUp()
+        self.path = "x/" * 10
+        self.r, self.w = os.pipe()
+        self.children = []
+        for i in range(8):
+            pid = os.fork()
+            if pid == 0:
+                self.child()
+            self.children.append(pid)
+
+    # @unittest.expectedFailure
+    def runTest(self):
+        """Test concurrent calls of oelite.util.makedirs"""
+
+        os.write(self.w, "go go go\n")
+        time.sleep(0.01)
+        os.close(self.w)
+        with os.fdopen(self.r) as f:
+            v = [v.strip() for v in f]
+        d = {x: v.count(x) for x in v if x != "go go go"}
+        # On failure this won't give a very user-friendly error
+        # message, but it should contain information about the errors
+        # encountered.
+        self.assertEqual(d, {"OK": len(self.children)})
+        self.assertTrue(os.path.isdir(self.path))
+
+    def tearDown(self):
+        for pid in self.children:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        super(MakedirsRaceTest, self).tearDown()
+
+    
+def run(options, args, config):
+    suite = unittest.TestSuite()
+    suite.addTest(MakedirsRaceTest())
+    if options.show:
+        for t in suite:
+            print str(t), "--", t.shortDescription()
+        return 0
+    runner = unittest.TextTestRunner(verbosity=3)
+    runner.run(suite)
+
+    return 0

--- a/lib/oelite/cmd/test.py
+++ b/lib/oelite/cmd/test.py
@@ -55,7 +55,6 @@ class MakedirsRaceTest(OEliteTest):
                 self.child()
             self.children.append(pid)
 
-    # @unittest.expectedFailure
     def runTest(self):
         """Test concurrent calls of oelite.util.makedirs"""
 

--- a/lib/oelite/compat.py
+++ b/lib/oelite/compat.py
@@ -57,25 +57,3 @@ else:
     except KeyError:
         dup_cloexec = dup_cloexec_fallback
 
-
-def has_cloexec(fd):
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    return (flags & fcntl.FD_CLOEXEC) != 0
-
-def test_open_cloexec():
-    fd = open_cloexec("/dev/null", os.O_RDONLY)
-    assert(has_cloexec(fd))
-    os.close(fd)
-    fd = open_cloexec("/dev/null", os.O_WRONLY)
-    assert(has_cloexec(fd))
-    os.close(fd)
-
-def test_dup_cloexec():
-    fd = dup_cloexec(sys.stdin.fileno())
-    assert(has_cloexec(fd))
-    os.close(fd)
-
-
-if __name__ == "__main__":
-    test_open_cloexec()
-    test_dup_cloexec()

--- a/lib/oelite/fetch/fetch.py
+++ b/lib/oelite/fetch/fetch.py
@@ -228,29 +228,6 @@ class OEliteUri:
             print "%s: no checksum known for %s"%(self.recipe, url)
             return ""
 
-    def cache(self):
-        if not "cache" in dir(self.fetcher):
-            return True
-        return self.fetcher.cache()
-
-    def write_checksum(self, filepath):
-        md5path = filepath + ".md5"
-        checksum = hashlib.md5()
-        with open(filepath) as f:
-            checksum.update(f.read())
-        with open(md5path, "w") as f:
-            f.write(checksum.digest())
-
-    def verify_checksum(self, filepath):
-        md5path = filepath + ".md5"
-        if not os.path.exists(md5path):
-            return None
-        checksum = hashlib.md5()
-        with open(filepath) as f:
-            checksum.update(f.read())
-        with open(md5path) as f:
-            return f.readline().strip() == checksum.digest()
-
     def fetch(self):
         if not "fetch" in dir(self.fetcher):
             return True

--- a/lib/oelite/fetch/fetch.py
+++ b/lib/oelite/fetch/fetch.py
@@ -328,13 +328,11 @@ class OEliteUri:
         dst = os.path.join(mirror, src[len(self.ingredients)+1:])
         if os.path.exists(dst):
             m = hashlib.md5()
-            with open(src, "r") as srcfile:
-                m.update(srcfile.read())
-                src_md5 = m.hexdigest()
+            oelite.util.hash_file(m, src)
+            src_md5 = m.hexdigest()
             m = hashlib.md5()
-            with open(dst, "r") as dstfile:
-                m.update(dstfile.read())
-                dst_md5 = m.hexdigest()
+            oelite.util.hash_file(m, dst)
+            dst_md5 = m.hexdigest()
             if src_md5 != dst_md5:
                 print "Mirror inconsistency:", dst
                 print "%s != %s"%(src_md5, dst_md5)

--- a/lib/oelite/fetch/local.py
+++ b/lib/oelite/fetch/local.py
@@ -1,5 +1,6 @@
 import oelite.fetch
 import oelite.path
+import oelite.util
 import os
 import hashlib
 
@@ -35,6 +36,6 @@ class LocalFetcher():
         if os.path.isdir(self.localpath):
             raise oelite.fetch.NoSignature(self.uri, "can't compute directory signature")
         m = hashlib.sha1()
-        m.update(open(self.localpath, "r").read())
+        oelite.util.hash_file(m, self.localpath)
         self._signature = m.digest()
         return self._signature

--- a/lib/oelite/fetch/url.py
+++ b/lib/oelite/fetch/url.py
@@ -83,7 +83,7 @@ class UrlFetcher():
 
     def localsignature(self):
         m = hashlib.sha1()
-        m.update(open(self.localpath, "r").read())
+        oelite.util.hash_file(m, self.localpath)
         return m.hexdigest()
 
     def get_proxies(self, d):

--- a/lib/oelite/signal.py
+++ b/lib/oelite/signal.py
@@ -30,34 +30,3 @@ def restore_defaults():
         signal.signal(signal.SIGXFZ, signal.SIG_DFL)
     if hasattr(signal, "SIGXFSZ"):
         signal.signal(signal.SIGXFSZ, signal.SIG_DFL)
-
-def test_restore():
-    import os
-    import subprocess
-    import errno
-
-    PIPE=subprocess.PIPE
-    sub = subprocess.Popen(["yes"], stdout=PIPE, stderr=PIPE)
-    # Force a broken pipe.
-    sub.stdout.close()
-    err = sub.stderr.read()
-    # This should terminate with a write error; we assume that 'yes'
-    # is so well-behaved that it both exits with a non-zero exit code
-    # as well as prints an error message containing strerror(errno).
-    ret = sub.wait()
-    assert(ret > 0)
-    assert(os.strerror(errno.EPIPE) in err)
-
-    sub = subprocess.Popen(["yes"], stdout=PIPE, stderr=PIPE, preexec_fn = restore_defaults)
-    # Force a broken pipe.
-    sub.stdout.close()
-    err = sub.stderr.read()
-    # This should terminate due to SIGPIPE, and not get a chance to write to stderr.
-    ret = sub.wait()
-    assert(ret == -signal.SIGPIPE)
-    assert(err == "")
-
-if __name__ == "__main__":
-    # To run:
-    # meta/core/lib$ python -m oelite.signal
-    test_restore()

--- a/lib/oelite/util.py
+++ b/lib/oelite/util.py
@@ -265,3 +265,17 @@ def timing_info(msg, start):
     msg += pretty_time(delta)
     info(msg)
     return
+
+def chunk_iter(fn, chunk_size = 32768):
+    with open(fn) as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if chunk:
+                yield chunk
+            else:
+                return
+
+def hash_file(hasher, fn):
+    for chunk in chunk_iter(fn):
+        hasher.update(chunk)
+    return hasher


### PR DESCRIPTION
While working on trying to allow async do_fetch and other python functions, I've realized I'm gonna need some low-level helpers (lockfiles, some signal handling), and that stuff is tricky enough that I want to be able to test those directly. Our makedirs helper also turned out to be racy, so the first test case is rather complex.

While at it, move the tiny existing self tests to 'oe test' so that they can get run without odd python invocations. Also, I use this opportunity to add a little performance improvement to do_fetch; being able to write a test for the new helper in just a few lines makes me much more confident that the new code really is equivalent to the old.

I also plan to add some sort of unit tests of our various task functions (for example, to allow refactoring do_split while being confident that the semantics don't change, and if they do, that it's deliberate and documented in the commit message why), but that is likely to be in the form of special-purpose recipes.