### PR TITLE
metadata: delete various stuff that will never be used

### DIFF
--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -569,8 +569,9 @@ class CookBook(Mapping):
                 os.remove(cachefile)
 
         for recipe_type in recipes:
-            oelite.pyexec.exechooks(recipes[recipe_type].meta,
-                                    "pre_cookbook")
+            meta = recipes[recipe_type].meta
+            oelite.pyexec.exechooks(meta, "pre_cookbook")
+            meta.trim_unused_overrides()
             self.add_recipe(recipes[recipe_type])
 
         return True

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -80,6 +80,10 @@ class CookBook(Mapping):
 
         self.create_world_recipes()
 
+        # All recipes parsed, no reason to hold on to the layer
+        # metadata (this frees a few MB of memory).
+        del self.layer_meta
+
         #print "when instantiating from a parsed oefile, do some 'finalizing', ie. collapsing of overrides and append, and remember to save expand_cache also"
 
         return

--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -572,6 +572,7 @@ class CookBook(Mapping):
             meta = recipes[recipe_type].meta
             oelite.pyexec.exechooks(meta, "pre_cookbook")
             meta.trim_unused_overrides()
+            meta.del_var("__mtimes")
             self.add_recipe(recipes[recipe_type])
 
         return True


### PR DESCRIPTION
These patches reduce our memory consumption somewhat as well as make metadata hashing faster. The biggest one is the first which seems to cut 18% of the memory (obviously depending on use flags, architecture etc.); the others are icing I stumbled on a while ago.