### PR TITLE
oelite/fetch/fetch.py: allow mirror=0 parameter to avoid mirroring

### DIFF
--- a/classes/mirror.oeclass
+++ b/classes/mirror.oeclass
@@ -8,6 +8,7 @@ addtask mirror after fetch
 addtask mirrorall after mirror
 
 MIRRORDIR ?= ""
+MIRRORDIR[emit] = "do_mirror"
 
 do_mirror[dirs] = "${WORKDIR} ${MIRRORDIR}"
 def do_mirror(d):

--- a/lib/oelite/fetch/fetch.py
+++ b/lib/oelite/fetch/fetch.py
@@ -318,6 +318,9 @@ class OEliteUri:
         return oelite.util.shcmd(cmd)
 
     def mirror(self, d, mirror):
+        if not int(self.params.get("mirror", 1)):
+            print "Skipping mirroring of %s due to mirror parameter" % self
+            return True
         if not "localpath" in dir(self.fetcher):
             if not "mirror" in dir(self.fetcher):
                 return True


### PR DESCRIPTION
It may be desirable to exempt some ingredients from being added to a
mirror server. Setting mirror=0 in the SRC_URI is a simple way of
achieving that.