### PR TITLE
class/kernel: Remove those .*.cmd files

### DIFF
--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -365,7 +365,7 @@ do_install_kernel () {
         mkdir -p ${D}${kernelsrcdir}/$machdir
         cp -fR $d ${D}${kernelsrcdir}/$machdir/
     done
-    #find ${D}${kernelsrcdir}/ \( -name \*.o -o -name .\*.cmd \) -exec rm {} \;
+    find ${D}${kernelsrcdir}/ \( -name \*.o -o -name .\*.cmd \) -delete
 }
 
 do_install () {


### PR DESCRIPTION
I don't believe there are any use of them in kernel-dev packages, and
many of them hardcode path to the originating recipe workdir, which
is obviously bad (with or without rmwork!).

Could/should we remove the .o files also?  Do they serve a purpose in
kernel-dev packages?

Signed-off-by: Esben Haabendal <esben@haabendal.dk>