### PR TITLE
lib/oelite/cookbook.py: open database with isolation_level=None

### DIFF
--- a/lib/oelite/cookbook.py
+++ b/lib/oelite/cookbook.py
@@ -29,7 +29,7 @@ class CookBook(Mapping):
         self.config = baker.config
         self.oeparser = baker.oeparser
         self.init_layer_meta()
-        self.db = sqlite.connect(":memory:")
+        self.db = sqlite.connect(":memory:", isolation_level=None)
         if not self.db:
             raise Exception("could not create in-memory sqlite db")
         self.db.text_factory = str


### PR DESCRIPTION
Using pysqlite >= 2.8 (the current version installed via pip is
2.8.3), oe-lite spits out

    self.cookbook.db.execute("ATTACH ':memory:' AS runq")
OperationalError: cannot ATTACH database within transaction
CRITICAL: bake failed: Exception: cannot ATTACH database within transaction

during initialization. This is due to a deliberate change in pysqlite
- see commits 94eae5, 90f6fe, cae87e, the latter of which adds the
text

 .. versionchanged:: 2.8.0
     pysqlite used to implicitly commit an open transaction before DDL statements.
     This is no longer the case.

Fix this by completely disabling the "automatically open a
transaction" logic for the database connection. For an in-memory
database that is only accessed by a single process, transactions don't
make much sense anyway. (If we ever wanted to do something where we
might want to do a rollback, we can do a BEGIN manually.)

This should be compatible with all versions of pysqlite.