### PR TITLE
classes/s6rc: allow use of class variables over USE flags

### DIFF
--- a/classes/s6rc.oeclass
+++ b/classes/s6rc.oeclass
@@ -80,13 +80,16 @@ python do_install_s6rc () {
 
     for sv in oneshot_services + longrun_services:
         sv_ = sv.translate(string.maketrans('-', '_'))
-        timeout_up = d.get('USE_%s_s6rc_timeout_up' % sv_)
+        timeout_up = d.get('S6RC_TIMEOUT_UP_%s' % sv_) or \
+            d.get('USE_%s_s6rc_timeout_up' % sv_)
         if timeout_up:
             write_service_file(sv, 'timeout-up', timeout_up + '\n')
-        timeout_down = d.get('USE_%s_s6rc_timeout_down' % sv_)
+        timeout_down = d.get('S6RC_TIMEOUT_DOWN_%s' % sv_) or \
+            d.get('USE_%s_s6rc_timeout_down' % sv_)
         if timeout_down:
             write_service_file(sv, 'timeout-down', timeout_down + '\n')
-        dependencies = d.get('USE_%s_s6rc_dependencies' % sv_)
+        dependencies = d.get('S6RC_DEPENDENCIES_%s' % sv_) or \
+            d.get('USE_%s_s6rc_dependencies' % sv_)
         if dependencies:
             dependencies = '\n'.join(dependencies.split() + [''])
             write_service_file(sv, 'dependencies', dependencies)
@@ -94,7 +97,8 @@ python do_install_s6rc () {
     for sv in bundle_services:
         sv_ = sv.translate(string.maketrans('-', '_'))
         write_service_file(sv, 'type', 'bundle\n')
-        contents = d.get('USE_%s_s6rc_bundle' % sv_) or ''
+        contents = d.get('S6RC_BUNDLE_%s' % sv_) or \
+            d.get('USE_%s_s6rc_bundle' % sv_) or ''
         contents = '\n'.join(contents.split() + [''])
         write_service_file(sv, 'contents', contents)
 


### PR DESCRIPTION
The s6rc class tracks certain settings for init script with USE flags,
which is handy if a machine or distro wants to override the recipe
defaults.

However, the use of USE flags makes it impossible for the recipe to use
other USE flags to set those s6rc USE flags (confusing wording intended
here).

For example, recipe `initscripts.oe` installs service 'foo-init' that
depends on 'bar-init', but conditionally on a USE flag:

    RECIPE_FLAGS += " \
        initscripts_foo_init \
        foo_init_s6rc_dependencies \
        foo_init_s6rc_bundle \
        foo_init_s6rc_timeout_up \
        foo_init_s6rc_timeout_down \
    "
    DEFAULT_USE_initscripts_foo_init = "0"
    SRC_URI:>USE_initscripts_foo_init = " file://foo-init"
    S6RC_ONESHOT_SERVICES:>USE_initscripts_foo_init = " foo-init"

    # These lines don't work:
    DEFAULT_USE_foo_init_s6rc_dependencies:>USE_initscripts_foo_init = " bar-init"
    DEFAULT_USE_foo_init_s6rc_bundle:>USE_initscripts_foo_init = " john-init doe-init"
    DEFAULT_USE_foo_init_s6rc_timeout_up:USE_initscripts_foo_init = "60"
    DEFAULT_USE_foo_init_s6rc_timeout_down:USE_initscripts_foo_init = "120"

So, to allow the use of USE flags to set s6rc settings, the class is
updated to check class variables first, and fall back to USE if the
variable is not defined.

The same example again, now with class variables:

    RECIPE_FLAGS += "initscripts_foo_init"
    DEFAULT_USE_initscripts_foo_init = "0"
    SRC_URI:>USE_initscripts_foo_init = " file://foo-init"
    S6RC_ONESHOT_SERVICES:>USE_initscripts_foo_init = " foo-init"

    # These lines work:
    S6RC_DEPENDENCIES_foo_init:>USE_initscripts_foo_init = " bar-init"
    S6RC_BUNDLE_foo_init:>USE_initscripts_foo_init = " john-init doe-init"
    S6RC_TIMEOUT_UP_foo_init:USE_initscripts_foo_init = "60"
    S6RC_TIMEOUT_DOWN_foo_init:USE_initscripts_foo_init = "120"