### PR TITLE
chrpath.oeclass: fix for setuid/setgid files

### DIFF
--- a/classes/chrpath.oeclass
+++ b/classes/chrpath.oeclass
@@ -58,14 +58,20 @@ def do_chrpath(d):
                 if recursive:
                     chrpath_dir(path, recursive, replace)
                 continue
-            chrpath = chrpath_get_cmd(d,filemagic.file(path))
-            if not chrpath:
-                continue
+
             mode = os.stat(path)[stat.ST_MODE]
-            if os.access(path, os.W_OK|os.R_OK):
+            highbits = (stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX)
+            if os.access(path, os.W_OK|os.R_OK) and (mode & highbits) == 0:
                 mode = None
             else:
-                os.chmod(path, mode|stat.S_IRWXU)
+                os.chmod(path, (mode|stat.S_IRWXU) & ~highbits)
+
+            chrpath = chrpath_get_cmd(d,filemagic.file(path))
+            if not chrpath:
+                if mode is not None:
+                    os.chmod(path, mode)
+                continue
+
             if replace:
                 cmd = [chrpath, '-l', path]
                 old_rpath = oelite.util.shcmd(cmd, quiet=True,


### PR DESCRIPTION
When a file has the setuid/setgid bits set, filemagic returns a string
such as

setuid, setgid ELF 32-bit LSB executable, ARM...

but in chrpath_get_cmd, we look for the regexp "ELF 32-bit ..." using
.match, which (contrary to .search) implicitly anchors the regexp at
the beginning. Hence we fail to return a chrpath command to use.

At first, I tried to fix this by either using .search, or by removing
leading occurences of "setuid,? ?", "setgid,? ?" in the filetype argument
in chrpath_get_cmd. However, it turns out that if we end up doing the
"chrpath -d" or whatnot, the kernel automatically clears the
setuid/setgid bits, so we'd have to restore them manually anyway in
do_chrpath. So since we already have a little chmod logic there, extend
the read-write test to also insist that the setuid/setgid/sticky bits
are not there. It gets a little ugly since we of course have to do that
before the filemagic call, so in case we end up in the "not chrpath"
branch, there's still a mode restoring to do.

This is especially relevant to busybox, since failing to clear the RPATH
means that every single invocation of a busybox applet starts by doing a
ton of

  open("/home/user/tmp/work/$REDACTED/busybox-1.25.1/install/usr/lib/tls/v7l/neon/vfp/libc.so.6", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
  stat64("/home/user/tmp/work/$REDACTED/busybox-1.25.1/install/usr/lib/tls/v7l/neon/vfp", 0x7eef77b0) = -1 ENOENT (No such file or directory)
  ...

which alone seem to cost about 0.3 - 0.5 ms.