### PR TITLE
s6rc.oeclass: automatically declare the correct flags

### DIFF
--- a/classes/s6rc.oeclass
+++ b/classes/s6rc.oeclass
@@ -19,13 +19,13 @@ def s6_use_flags(d):
 
     for sv in oneshot_services + longrun_services:
         for sfx in ["timeout_up", "timeout_down", "dependencies"]:
-            flag = "USE_" + sv + "s6rc_" + sfx
+            flag = sv + "_s6rc_" + sfx
             if flag not in use_flags:
                 class_flags.append(flag)
 
     for sv in bundle_services:
         for sfx in ["bundle"]:
-            flag = "USE_" + sv + "s6rc_" + sfx
+            flag = sv + "_s6rc_" + sfx
             if flag not in use_flags:
                 class_flags.append(flag)
 


### PR DESCRIPTION
This is embarrassing. I'm 99% convinced I tested this at some point, but
somehow I've managed to both include a "USE_" prefix which should not be
there as well as leaving out the underscore between the service name and
"s6rc".

Fixes b4330e6 - s6rc.oeclass: automatically declare flags