### PR TITLE
class/elfwrapper: Do not fork

### DIFF
--- a/classes/elfwrapper.oeclass
+++ b/classes/elfwrapper.oeclass
@@ -69,7 +69,8 @@ def image_preprocess_elf_sowrap(d):
                 dirparts = len(os.path.dirname(path).split('/'))
                 relative_root = "/".join([".."] * dirparts)
                 wrapper.write("#!/bin/sh\n")
-                wrapper.write("exec $(dirname $(readlink -f $0))/%s%s $(dirname $(readlink -f $0))/%s \"$@\""%(
+                wrapper.write("dir=$(dirname $(readlink -f $0))\n")
+                wrapper.write("exec $dir/%s%s $dir/%s \"$@\""%(
                         relative_root, ld_so, os.path.basename(dotpath)))
             shutil.copymode(dotpath, path)
         return True

--- a/classes/elfwrapper.oeclass
+++ b/classes/elfwrapper.oeclass
@@ -68,7 +68,7 @@ def image_preprocess_elf_sowrap(d):
                 dirparts = len(os.path.dirname(path).split('/'))
                 relative_root = "/".join([".."] * dirparts)
                 wrapper.write("#!/bin/sh\n")
-                wrapper.write("$(dirname $(readlink -f $0))/%s%s $(dirname $(readlink -f $0))/%s \"$@\""%(
+                wrapper.write("exec $(dirname $(readlink -f $0))/%s%s $(dirname $(readlink -f $0))/%s \"$@\""%(
                         relative_root, ld_so, os.path.basename(dotpath)))
             os.chmod(path, stat.S_IRWXU|stat.S_IRWXG|stat.S_IROTH|stat.S_IXOTH)
         return True

--- a/classes/elfwrapper.oeclass
+++ b/classes/elfwrapper.oeclass
@@ -22,6 +22,7 @@ IMAGE_PREPROCESS_ELF_SOWRAP:HOST_BINFMT_elf = " image_preprocess_elf_sowrap"
 def image_preprocess_elf_sowrap(d):
     import stat
     import oelite.magiccache
+    import shutil
 
     filemagic = oelite.magiccache.open()
     host_elf_re = re.compile(d.get("HOST_ELF"))
@@ -70,7 +71,7 @@ def image_preprocess_elf_sowrap(d):
                 wrapper.write("#!/bin/sh\n")
                 wrapper.write("exec $(dirname $(readlink -f $0))/%s%s $(dirname $(readlink -f $0))/%s \"$@\""%(
                         relative_root, ld_so, os.path.basename(dotpath)))
-            os.chmod(path, stat.S_IRWXU|stat.S_IRWXG|stat.S_IROTH|stat.S_IXOTH)
+            shutil.copymode(dotpath, path)
         return True
 
     bindirs = set(d.get("IMAGE_ELF_SOWRAP_DIRS").split())


### PR DESCRIPTION
Avoid forking of, making a bit more convenient to keep track of the PID
of the process.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>