### PR TITLE
class/elfwrapper: Set argv[0] to wrapper instead of wrapped cmd

### DIFF
--- a/classes/elfwrapper.oeclass
+++ b/classes/elfwrapper.oeclass
@@ -70,7 +70,7 @@ def image_preprocess_elf_sowrap(d):
                 relative_root = "/".join([".."] * dirparts)
                 wrapper.write("#!/bin/sh\n")
                 wrapper.write("dir=$(dirname $(readlink -f $0))\n")
-                wrapper.write("exec $dir/%s%s $dir/%s \"$@\""%(
+                wrapper.write("exec -a $0 $dir/%s%s $dir/%s \"$@\""%(
                         relative_root, ld_so, os.path.basename(dotpath)))
             shutil.copymode(dotpath, path)
         return True


### PR DESCRIPTION
When calling the wrapped command, set argv[0] to the wrapper
argv[0] instead of the full path to the wrapped command.

This should be safer, as argv[0] can be used by the wrapped
command (where as the full path to the wrapped command is not
safe to call directly).  Also, commands using argv[0] for usage
information looks nicer.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>