### PR TITLE
class/manifest-version: Only consider matching tags

### DIFF
--- a/classes/manifest-version.oeclass
+++ b/classes/manifest-version.oeclass
@@ -7,8 +7,13 @@
 ## @useflag manifest_version_dirty_mark Custom string to append if manifest is
 ##          dirty.
 ## @useflag manifest_version_strip_leading If set, the leading prefix
-##          specified by this flag will be stripped if the version string is
-##          starting with the prefix followed by a decimal number.
+##          specified by this flag will be stripped if the version string (tag)
+##          is starting with the prefix followed by a decimal number.
+## @useflag manifest_version_tag_match If set, only tags matching this glob(7)
+##          will be used.  If not set, but USE_manifest_version_strip_leading
+##          is set, only tags starting with that will be used.  If not set and
+##          USE_manifest_version_strip_leading is not set, all tags will be
+##          considered..
 ## @useflag manifest_version_cmd If set, this is used as the entire
 ##          command to execute to produce the version. The string is
 ##          interpreted by "sh -c", so some quoting may be necessary.
@@ -19,7 +24,7 @@ CLASS_DEPENDS += "native:git"
 __dont_cache = True
 
 CLASS_FLAGS += "manifest_version_dirty_mark manifest_version_strip_leading"
-CLASS_FLAGS += "manifest_version_cmd"
+CLASS_FLAGS += "manifest_version_tag_match manifest_version_cmd"
 DEFAULT_USE_manifest_version_dirty_mark = "-dirty"
 
 addhook manifest_version to post_recipe_parse
@@ -29,7 +34,8 @@ def manifest_version(d):
     version = None
     cmd = d.get("USE_manifest_version_cmd", expand=False)
     if cmd:
-        sub = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        sub = subprocess.Popen(cmd, shell=True,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (out, err) = sub.communicate()
         if sub.returncode == 0:
             version = out.strip()
@@ -37,11 +43,17 @@ def manifest_version(d):
             sys.stderr.write("Command '%s' failed: %s" % (cmd, err))
             version = None
     elif os.path.exists(".git"):
-        sub = subprocess.Popen(["git", "describe", "--always",
-                                "--dirty="+d.get("USE_manifest_version_dirty_mark")],
+        strip_leading = d.get("USE_manifest_version_strip_leading")
+        tag_match = d.get("USE_manifest_version_tag_match")
+        if strip_leading and not tag_match:
+            tag_match = strip_leading + "*"
+        cmd = ["git", "describe", "--always",
+               "--dirty="+d.get("USE_manifest_version_dirty_mark")]
+        if tag_match:
+            cmd.append("--match=" + tag_match)
+        sub = subprocess.Popen(cmd,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         version = sub.communicate()[0].strip()
-        strip_leading = d.get("USE_manifest_version_strip_leading")
         if sub.returncode != 0:
             version = None
         elif (strip_leading and re.match('%s\d'%(strip_leading), version)):


### PR DESCRIPTION
This changes the behavior of USE_manifest_version_strip_leading, so that only
tags that matches this will be used.

With the previous behavior, the latest tag would always be used, and if it
matched, would be stripped accordingly.  For non-matching tags, they would
just be used as-is.

With this new behavior, the USE_manifest_version_strip_leading can be safely
used with the initial intent, which is to use it for for relase versioning
using tags with a specific prefix.  The OESTACK_VERSION will always be taken
as relative to the latest release, even if other type of (non-release) tags
have been added since then.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>