### PR TITLE
class/s6rc: Fix bug when RECIPE_FLAGS is not set

### DIFF
--- a/classes/s6rc.oeclass
+++ b/classes/s6rc.oeclass
@@ -15,7 +15,7 @@ def s6_use_flags(d):
     bundle_services = (d.get('S6RC_BUNDLE_SERVICES') or '').split()
 
     class_flags = (d.get('CLASS_FLAGS' or '')).split()
-    use_flags = class_flags + (d.get('RECIPE_FLAGS' or '')).split()
+    use_flags = class_flags + (d.get('RECIPE_FLAGS') or '').split()
 
     for sv in oneshot_services + longrun_services:
         for sfx in ["timeout_up", "timeout_down", "dependencies"]:


### PR DESCRIPTION
This fixes problems for recipes using s6rc.oeclass without any
RECIPE_FLAGS, as we will try to do None.split().

```
Traceback (most recent call last):
  File "/home/user/manifest/meta/core/lib/oelite/cookbook.py", line 57, in __init__
    if not self.add_recipefile(recipefile):
  File "/home/user/manifest/meta/core/lib/oelite/cookbook.py", line 554, in add_recipefile
    recipe_meta = self.parse_recipe(filename)
  File "/home/user/manifest/meta/core/lib/oelite/cookbook.py", line 683, in parse_recipe
    oelite.pyexec.exechooks(meta[recipe_type], "post_recipe_parse")
  File "/home/user/manifest/meta/core/lib/oelite/pyexec.py", line 44, in exechooks
    retval = hook.run(tmpdir)
  File "/home/user/manifest/meta/core/lib/oelite/function.py", line 37, in run
    self.start(cwd)
  File "/home/user/manifest/meta/core/lib/oelite/function.py", line 52, in start
    self._start()
  File "/home/user/manifest/meta/core/lib/oelite/function.py", line 60, in _start
    self.result = self()
  File "/home/user/manifest/meta/core/lib/oelite/function.py", line 120, in __call__
    retval = self.function(self.meta)
  File "/home/user/manifest/meta/core/classes/s6rc.oeclass", line 18, in s6_use_flags
    use_flags = class_flags + (d.get('RECIPE_FLAGS' or '')).split()
AttributeError: 'NoneType' object has no attribute 'split'
```

Signed-off-by: Esben Haabendal <esben@haabendal.dk>