### PR TITLE
class/kernel: Include localversion-rt in kernel-dev package

### DIFF
--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -353,6 +353,9 @@ do_install_kernel () {
     for file in Makefile .config Module.symvers System.map ; do
         cp -f $file ${D}${kernelsrcdir}
     done
+    for file in localversion-rt ; do
+        test -e $file && cp -f $file ${D}${kernelsrcdir}
+    done
     mkdir -p ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
     cp -fR arch/${KERNEL_ARCH}/lib ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}
     cp -fR arch/${KERNEL_ARCH}/include ${D}${kernelsrcdir}/arch/${KERNEL_ARCH}


### PR DESCRIPTION
The localversion-rt file is used by some buildsystems to know the
RT-Preempt baseline that a kernel is based on.