### PR TITLE
class/auto-package-libs: LIBRARY_VERSION specific -dev package provides

### DIFF
--- a/classes/auto-package-libs.oeclass
+++ b/classes/auto-package-libs.oeclass
@@ -172,6 +172,9 @@ def auto_package_libs (d):
         devpkg_provides = (d.get("PROVIDES_" + devpkg) or "").split()
         devpkg_provides.append("%s%s-dev"%(provideprefix,
                                            lib.replace("_", "-").lower()))
+        if library_version:
+            devpkg_provides.append("%s%s-%s-dev"%(
+                provideprefix, lib.replace("_","-").lower(), library_version))
         d.set("PROVIDES_" + devpkg, " ".join(devpkg_provides))
 
         pkg_depends = (d.get("DEPENDS_" + pkg) or "").split()

--- a/classes/auto-package-libs.oeclass
+++ b/classes/auto-package-libs.oeclass
@@ -153,14 +153,15 @@ def auto_package_libs (d):
         files += get_extra_files(devpkg)
         d.set("FILES_" + devpkg, " ".join(files))
 
+        library_version = (d.get("LIBRARY_VERSION_" + pkg) or
+                           d.get("LIBRARY_VERSION"))
+
         pkg_provides = (d.get("PROVIDES_" + pkg) or "").split()
         pkg_provides.append("%s%s"%(provideprefix,
                                     lib.replace("_", "-").lower()))
-        library_version = (d.get("LIBRARY_VERSION_" + pkg) or
-                           d.get("LIBRARY_VERSION"))
         if library_version:
-            pkg_provides.append(provideprefix + lib.replace("_","-").lower()
-                                + '-' + library_version)
+            pkg_provides.append("%s%s-%s"%(
+                provideprefix, lib.replace("_","-").lower(), library_version))
         d.set("PROVIDES_" + pkg, " ".join(pkg_provides))
 
         qaflags = (d.get_flag("PROVIDES_" + pkg,"qa") or "").split()


### PR DESCRIPTION
This makes sure that all recipes using auto-package-libs provides also
provides a LIBRARY_VERSION specific -dev item.

This is necessary when RDEPENDS_ for -dev packages are generated by
auto-package-libs.oeclass based on the normal package RDEPENDS, and when
these contains LIBRARY_VERSION specific dependencies.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>