### PR TITLE
kernel.oeclass: add escape hatch when building perf

### DIFF
--- a/classes/kernel.oeclass
+++ b/classes/kernel.oeclass
@@ -313,11 +313,13 @@ CLASS_FLAGS += "kernel_perf"
 DEPENDS:>USE_kernel_perf += " libpthread librt libm libdl"
 DO_INSTALL_PERF = ""
 DO_INSTALL_PERF:USE_kernel_perf = "do_install_perf"
+EXTRA_OEMAKE_PERF ?= ""
 do_install[postfuncs] += "${DO_INSTALL_PERF}"
 do_install_perf () {
         oe_runmake -C ${S}/tools/perf install DESTDIR=${D} \
                 prefix=${prefix} \
-                bindir=${bindir}
+                bindir=${bindir} \
+                ${EXTRA_OEMAKE_PERF}
 }
 PACKAGES:>USE_kernel_perf += " ${PN}-perf ${PN}-perf-doc ${PN}-perf-scripts"
 FILES_${PN}-perf = "${bindir}/perf ${bindir}/trace \


### PR DESCRIPTION
Some versions of perf do not build cleanly with certain gccs (e.g., an
old perf may trigger warnings/errors in new gccs). Since perf by
default uses -Werror, that breaks the entire build.

This adds an escape hatch so that one can say

EXTRA_OEMAKE_PERF = "WERROR=0"

in the kernel recipe to disable -Werror. Obviously, it can also be
used for other things.